### PR TITLE
mesa: update to version 21.3.0

### DIFF
--- a/frameworks/wayland-protocols/Makefile
+++ b/frameworks/wayland-protocols/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wayland-protocols
-PKG_VERSION:=1.21
+PKG_VERSION:=1.24
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://wayland.freedesktop.org/releases/
-PKG_HASH:=b99945842d8be18817c26ee77dafa157883af89268e15f4a5a1a1ff3ffa4cde5
+PKG_HASH:=bff0d8cffeeceb35159d6f4aa6bab18c807b80642c9d50f66cba52ecf7338bc2
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT
@@ -15,6 +15,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_INSTALL:=1
 
 PKG_BUILD_DEPENDS:=wayland
+HOST_BUILD_DEPENDS:=wayland/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk

--- a/frameworks/wayland/Makefile
+++ b/frameworks/wayland/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wayland
-PKG_VERSION:=1.19.0
+PKG_VERSION:=1.19.92
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://wayland.freedesktop.org/releases/
-PKG_HASH:=baccd902300d354581cd5ad3cc49daa4921d55fb416a5883e218750fef166d15
+PKG_SOURCE_URL:=https://wayland.freedesktop.org/releases
+PKG_HASH:=f8cbd8a8c713ed393e63e7c6ac81c6b9ef5a49a2b631717377fa78b80ac34cfa
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT
@@ -14,6 +14,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=libffi/host libxml2/host expat/host wayland/host
+HOST_BUILD_DEPENDS:=$(PKG_BUILD_DEPENDS)
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
@@ -48,6 +49,8 @@ MESON_HOST_ARGS += \
 	-Dlibraries=false \
 	-Ddocumentation=false \
 	-Ddtd_validation=true
+
+HOST_LDFLAGS += $(STAGING_DIR_HOST)/lib/libz.a -lm
 
 MESON_ARGS += \
 	-Dscanner=true \

--- a/frameworks/wayland/patches/001-fix-wayland-scanner-detect.patch
+++ b/frameworks/wayland/patches/001-fix-wayland-scanner-detect.patch
@@ -1,6 +1,6 @@
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -59,8 +59,12 @@ if get_option('scanner')
+@@ -70,8 +70,12 @@ if get_option('scanner')
  endif
  
  if meson.is_cross_build() or not get_option('scanner')
@@ -17,8 +17,8 @@
  endif
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -6,6 +6,10 @@ option('scanner',
-   description: 'Compile wayland-scanner binary',
+@@ -10,6 +10,10 @@ option('tests',
+   description: 'Compile Wayland tests',
    type: 'boolean',
    value: 'true')
 +option('scanner_bin',

--- a/libs/mesa/Makefile
+++ b/libs/mesa/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mesa
-PKG_VERSION:=21.1.7
+PKG_VERSION:=21.3.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://archive.mesa3d.org/
-PKG_HASH:=e9e67c10654f2e4bf15b944bb048007a614292aa4792b1b7512eb700b7b3a7bb
+PKG_HASH:=a2753c09deef0ba14d35ae8a2ceff3fe5cd13698928c7bb62c2ec8736eb09ce1
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
@@ -70,7 +70,7 @@ define Package/libxatracker
   SUBMENU:=Video
   TITLE:=Mesa3D libxatracker
   URL:=https://www.mesa3d.org
-  DEPENDS:=+libstdcpp +zlib +libdrm +libexpat
+  DEPENDS:=+libstdcpp +zlib +libdrm +libexpat @(aarch64||arm||i386||i686||x86_64)
 endef
 
 define Package/libxatracker/description
@@ -116,7 +116,7 @@ define Package/libvulkan-broadcom
   SECTION:=libs
   CATEGORY:=Libraries
   SUBMENU:=Video
-  DEPENDS:=libmesa @(arm||aarch64)
+  DEPENDS:=libmesa @(arm||aarch64) @BROKEN
   TITLE:=Broadcom Vulkan driver
   URL:=https://www.mesa3d.org
 endef
@@ -169,7 +169,6 @@ GALLIUM_DRIVERS:=kmsro swrast vc4 virgl
 
 ifneq ($(CONFIG_LIBDRM_INTEL),)
   DRI_DRIVERS+=i965
-  VULKAN_DRIVERS+=intel
   GALLIUM_DRIVERS+=i915
 endif
 
@@ -184,21 +183,8 @@ ifneq ($(CONFIG_LIBDRM_RADEON),)
 # r600 and radeonsi require LLVM
 endif
 
-ifeq ($(ARCH),x86_64)
-  GALLIUM_DRIVERS+=svga
-endif
-
-ifeq ($(ARCH),i386)
-  GALLIUM_DRIVERS+=svga
-endif
-
-ifeq ($(ARCH),i686)
-  GALLIUM_DRIVERS+=svga
-endif
-
 ifeq ($(ARCH),aarch64)
   GALLIUM_DRIVERS+=freedreno etnaviv panfrost lima
-  VULKAN_DRIVERS+=broadcom freedreno
 ifneq ($(CONFIG_LIBDRM_NOUVEAU),)
   GALLIUM_DRIVERS+=tegra
 endif
@@ -206,7 +192,6 @@ endif
 
 ifeq ($(ARCH),arm)
   GALLIUM_DRIVERS+=freedreno etnaviv panfrost lima
-  VULKAN_DRIVERS+=broadcom freedreno
 ifneq ($(CONFIG_LIBDRM_NOUVEAU),)
   GALLIUM_DRIVERS+=tegra
 endif
@@ -220,6 +205,29 @@ ifeq ($(ARCH),mipsel)
   GALLIUM_DRIVERS+=etnaviv
 endif
 
+ifeq ($(ARCH),x86_64)
+  GALLIUM_DRIVERS+=svga
+endif
+
+ifeq ($(ARCH),i386)
+  GALLIUM_DRIVERS+=svga
+endif
+
+ifeq ($(ARCH),i686)
+  GALLIUM_DRIVERS+=svga
+endif
+
+ifneq ($(CONFIG_PACKAGE_libvulkan-broadcom),)
+  VULKAN_DRIVERS+=broadcom
+endif
+
+ifneq ($(CONFIG_PACKAGE_libvulkan-freedreno),)
+  VULKAN_DRIVERS+=freedreno
+endif
+
+ifneq ($(CONFIG_PACKAGE_libvulkan-intel),)
+  VULKAN_DRIVERS+=intel
+endif
 
 MESON_ARGS += \
 	-Dplatforms=wayland \
@@ -241,6 +249,8 @@ MESON_ARGS += \
 	-Dshared-glapi=enabled \
 	-Ddraw-use-llvm=false \
 	-Dscanner_bin="$(STAGING_DIR_HOSTPKG)/bin/wayland-scanner"
+
+TARGET_CFLAGS += -I$(MESON_BUILD_DIR)/src/broadcom/
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/libs/mesa/patches/001-fix-wayland-scanner-detect.patch
+++ b/libs/mesa/patches/001-fix-wayland-scanner-detect.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -1830,12 +1830,17 @@ endif
+@@ -1973,12 +1973,17 @@ endif
  # TODO: symbol mangling
  
  if with_platform_wayland
@@ -25,7 +25,7 @@
    dep_wayland_client = dependency('wayland-client', version : '>=1.18')
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -456,6 +456,11 @@ option(
+@@ -486,6 +486,11 @@ option(
    value : 25,
    description : 'Android Platform SDK version. Default: Nougat version.'
  )


### PR DESCRIPTION
 * build vulkan drivers only if selected
 * disable broadcom vulkan driver as it causes meson-related
   build troubles (unrelated to the version bump)

Signed-off-by: Daniel Golle <daniel@makrotopia.org>