### PR TITLE
wayland: Use tools/expat instead of expat/host

### DIFF
--- a/frameworks/wayland/Makefile
+++ b/frameworks/wayland/Makefile
@@ -13,7 +13,7 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
-PKG_BUILD_DEPENDS:=libffi/host libxml2/host expat/host wayland/host
+PKG_BUILD_DEPENDS:=libffi/host libxml2/host wayland/host
 HOST_BUILD_DEPENDS:=$(PKG_BUILD_DEPENDS)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
As described in https://github.com/openwrt/packages/commit/5bf74f2ad434841bfe9c3013e55556c0005e74cb, packages that supposedly use `expat/host` actually use `tools/expat`.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>