### PR TITLE
treewide: refactor to use PKG_BUILD_FLAGS

### DIFF
--- a/frameworks/qt5base/Makefile
+++ b/frameworks/qt5base/Makefile
@@ -25,7 +25,7 @@ HOST_BUILD_DIR=$(BUILD_DIR)/host/$(PKG_SYS_NAME)
 PKG_BUILD_PARALLEL:=1
 HOST_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
-PKG_USE_MIPS16:=0
+PKG_BUILD_FLAGS:=no-mips16
 # Yes, the host build depends on the target build. This is not a mistake!
 # The target build provides the (target specific) qmake.mk file which
 # is also used for host builds.

--- a/libs/libdouble-conversion/Makefile
+++ b/libs/libdouble-conversion/Makefile
@@ -23,7 +23,7 @@ PKG_LICENSE:=BSD-3c
 PKG_LICENSE_FILES:=COPYING LICENSE
 
 CMAKE_INSTALL:=1
-PKG_BUILD_FLAGS:=gc-sections
+PKG_BUILD_FLAGS:=gc-sections lto
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
@@ -49,7 +49,7 @@ CMAKE_OPTIONS += \
 	-DBUILD_SHARED_LIBS=ON \
 	-DBUILD_TESTING=OFF
 
-TARGET_CXXFLAGS += -fno-rtti -flto
+TARGET_CXXFLAGS += -fno-rtti
 
 define Package/libdouble-conversion/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/libdouble-conversion/Makefile
+++ b/libs/libdouble-conversion/Makefile
@@ -23,6 +23,7 @@ PKG_LICENSE:=BSD-3c
 PKG_LICENSE_FILES:=COPYING LICENSE
 
 CMAKE_INSTALL:=1
+PKG_BUILD_FLAGS:=gc-sections
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
@@ -48,8 +49,7 @@ CMAKE_OPTIONS += \
 	-DBUILD_SHARED_LIBS=ON \
 	-DBUILD_TESTING=OFF
 
-TARGET_CXXFLAGS += -ffunction-sections -fdata-sections -fno-rtti -flto
-TARGET_LDFLAGS += -Wl,--gc-sections
+TARGET_CXXFLAGS += -fno-rtti -flto
 
 define Package/libdouble-conversion/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
This refactors packages to use the new PKG_BUILD_FLAGS feature added to the main repo.