### PR TITLE
add SDL2, SDL2_mixer and sdl2-doom

### DIFF
--- a/games/sdl2-doom/Makefile
+++ b/games/sdl2-doom/Makefile
@@ -1,0 +1,44 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=sdl2-doom
+PKG_SOURCE_DATE:=2022-03-06
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/AlexOberhofer/sdl2-doom
+PKG_SOURCE_VERSION:=da7732ee6318371db2ee04ec4702c6064245846b
+PKG_MIRROR_HASH:=871f9892ac49766e2729ae5c6ce1f75f830361aea048f2e8a64c3db63de7e121
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=License.md
+
+PKG_BUILD_FLAGS:=gc-sections lto
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/sdl2-doom
+  SECTION:=games
+  CATEGORY:=Games
+  TITLE:=SDL2 Doom
+  URL:=https://github.com/AlexOberhofer/sdl2-doom
+  DEPENDS:=+libstdcpp +libsdl2 +libsdl2-mixer
+endef
+
+define Package/sdl2-doom/description
+  This is a source port of the ID Software source release of DOOM.
+  Using low-resolution software rendering designed in 1993 by idSoftware
+  for (from today's perspective) very slow CPUs it runs with good
+  performance even on low-end devices.
+endef
+
+define Package/sdl2-doom/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/sdl2-doom $(1)/usr/bin
+endef
+
+define Build/Install
+endef
+
+$(eval $(call BuildPackage,sdl2-doom))

--- a/libs/sdl2-mixer/Makefile
+++ b/libs/sdl2-mixer/Makefile
@@ -1,0 +1,54 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=sdl2-mixer
+PKG_VERSION:=2.8.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=SDL2_mixer-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/libsdl-org/SDL_mixer/tar.gz/release-$(PKG_VERSION)?
+PKG_HASH:=1146f00815c8ad22c3d48fbe31ae23dc5997936ebf30b4b3aeab6eab7ea1db3e
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/SDL_mixer-release-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=BSD-3c
+PKG_LICENSE_FILES:=COPYING LICENSE
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_BINARY_SUBDIR:=openwrt-build
+
+CMAKE_OPTIONS += \
+	-DSDL2MIXER_MIDI_FLUIDSYNTH_SHARED=ON
+
+define Build/InstallDev
+	$(call Build/InstallDev/cmake,$(1))
+ifdef CONFIG_DEBUG
+	$(LN) libSDL2_mixerd.so $(1)/usr/lib/libSDL2_mixer.so
+endif
+endef
+
+define Package/libsdl2-mixer
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=SDL2 Mixer
+  URL:=https://www.libsdl.org/
+  DEPENDS:=+libfluidsynth +libopusfile +libsdl2 +libwavpack +libxmp
+endef
+
+define Package/libsdl2-mixer/description
+  SDL Audio Mixer library
+endef
+
+define Package/libsdl2-mixer/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so* $(1)/usr/lib/
+ifdef CONFIG_DEBUG
+	$(LN) libSDL2_mixerd.so $(1)/usr/lib/libSDL2_mixer.so
+endif
+endef
+
+$(eval $(call BuildPackage,libsdl2-mixer))

--- a/libs/sdl2/Makefile
+++ b/libs/sdl2/Makefile
@@ -1,0 +1,154 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=sdl2
+PKG_VERSION:=2.30.9
+PKG_RELEASE:=1
+
+PKG_SOURCE:=SDL2-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://www.libsdl.org/release/
+PKG_HASH:=24b574f71c87a763f50704bbb630cbe38298d544a1f890f099a4696b1d6beba4
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/SDL2-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=BSD-3c
+PKG_LICENSE_FILES:=COPYING LICENSE
+
+CMAKE_INSTALL:=1
+PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_libsdl2-tests
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_BINARY_SUBDIR:=openwrt-build
+
+CMAKE_OPTIONS += \
+	-DSDL_ALSA=ON \
+	-DSDL_ALSA_SHARED=ON \
+	-DSDL_ARTS=OFF \
+	-DSDL_ARTS_SHARED=OFF \
+	-DSDL_ASAN=OFF \
+	-DSDL_BACKGROUNDING_SIGNAL=OFF \
+	-DSDL_CCACHE=OFF \
+	-DSDL_CLOCK_GETTIME=ON \
+	-DSDL_COCOA=OFF \
+	-DSDL_DBUS=OFF \
+	-DSDL_DIRECTFB=OFF \
+	-DSDL_DIRECTFB_SHARED=OFF \
+	-DSDL_DIRECTX=OFF \
+	-DSDL_DISKAUDIO=OFF \
+	-DSDL_DUMMYAUDIO=ON \
+	-DSDL_DUMMYVIDEO=ON \
+	-DSDL_ESD=OFF \
+	-DSDL_ESD_SHARED=OFF \
+	-DSDL_FOREGROUNDING_SIGNAL=OFF \
+	-DSDL_FUSIONSOUND=OFF \
+	-DSDL_FUSIONSOUND_SHARED=OFF \
+	-DSDL_GCC_ATOMICS=ON \
+	-DSDL_HIDAPI=ON \
+	-DSDL_HIDAPI_JOYSTICK=ON \
+	-DSDL_HIDAPI_LIBUSB=ON \
+	-DSDL_IBUS=OFF \
+	-DSDL_JACK=OFF \
+	-DSDL_JACK_SHARED=OFF \
+	-DSDL_KMSDRM=ON \
+	-DSDL_KMSDRM_SHARED=ON \
+	-DSDL_LASX=OFF \
+	-DSDL_LIBC=ON \
+	-DSDL_LIBICONV=OFF \
+	-DSDL_LIBSAMPLERATE=ON \
+	-DSDL_LIBSAMPLERATE_SHARED=ON \
+	-DSDL_LIBUDEV=ON \
+	-DSDL_LSX=OFF \
+	-DSDL_METAL=OFF \
+	-DSDL_MMX=OFF \
+	-DSDL_NAS=OFF \
+	-DSDL_NAS_SHARED=OFF \
+	-DSDL_OFFSCREEN=ON \
+	-DSDL_OPENGL=ON \
+	-DSDL_OPENGLES=ON \
+	-DSDL_OSS=OFF \
+	-DSDL_PIPEWIRE=OFF \
+	-DSDL_PIPEWIRE_SHARED=OFF \
+	-DSDL_PTHREADS=ON \
+	-DSDL_PTHREADS_SEM=ON \
+	-DSDL_PULSEAUDIO=ON \
+	-DSDL_PULSEAUDIO_SHARED=ON \
+	-DSDL_RENDER_D3D=OFF \
+	-DSDL_RENDER_METAL=OFF \
+	-DSDL_RPATH=OFF \
+	-DSDL_RPI=OFF \
+	-DSDL_SNDIO=OFF \
+	-DSDL_SNDIO_SHARED=OFF \
+	-DSDL_SYSTEM_ICONV=OFF \
+	-DSDL_TESTS=$(if $(CONFIG_PACKAGE_libsdl2-tests),ON,OFF) \
+	-DSDL_INSTALL_TESTS=$(if $(CONFIG_PACKAGE_libsdl2-tests),ON,OFF) \
+	-DSDL_VENDOR_INFO=OFF \
+	-DSDL_VIRTUAL_JOYSTICK=OFF \
+	-DSDL_VIVANTE=OFF \
+	-DSDL_VULKAN=ON \
+	-DSDL_WASAPI=OFF \
+	-DSDL_WAYLAND=ON \
+	-DSDL_WAYLAND_LIBDECOR=OFF \
+	-DSDL_WAYLAND_LIBDECOR_SHARED=OFF \
+	-DSDL_WAYLAND_QT_TOUCH=ON \
+	-DSDL_WAYLAND_SHARED=ON \
+	-DSDL_X11=OFF \
+	-DSDL_X11_SHARED=OFF \
+	-DSDL_X11_XCURSOR=OFF \
+	-DSDL_X11_XDBE=OFF \
+	-DSDL_X11_XFIXES=OFF \
+	-DSDL_X11_XINPUT=OFF \
+	-DSDL_X11_XRANDR=OFF \
+	-DSDL_X11_XSCRNSAVER=OFF \
+	-DSDL_X11_XSHAPE=OFF \
+	-DSDL_XINPUT=OFF
+
+define Package/libsdl2
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Simple DirectMedia Layer
+  URL:=https://www.libsdl.org
+  DEPENDS:=+libstdcpp +alsa-lib +libudev-zero +pulseaudio +libmesa +libsamplerate +libwayland +wayland-protocols
+endef
+
+define Package/libsdl2/description
+ Simple DirectMedia Layer is a cross-platform development library designed to
+ provide low level access to audio, keyboard, mouse, joystick, and graphics
+ hardware via OpenGL and Direct3D.
+endef
+
+define Build/InstallDev
+	$(call Build/InstallDev/cmake,$(1))
+ifdef CONFIG_DEBUG
+	$(LN) libSDL2d.so $(1)/usr/lib/libSDL2.so
+endif
+endef
+
+define Package/libsdl2/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libSDL2*.so* $(1)/usr/lib
+ifdef CONFIG_DEBUG
+	$(LN) libSDL2d.so $(1)/usr/lib/libSDL2.so
+endif
+endef
+
+define Package/libsdl2-tests
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=SDL installed tests
+  URL:=https://www.libsdl.org
+  DEPENDS:=+libsdl2
+endef
+
+define Package/libsdl2-tests/description
+ Various test programs to validate SDL is working correctly, and some benchmarks.
+endef
+
+define Package/libsdl2-tests/install
+	$(INSTALL_DIR) $(1)/usr/libexec/installed-tests
+	$(CP) $(PKG_INSTALL_DIR)/usr/libexec/installed-tests/* $(1)/usr/libexec/installed-tests
+endef
+
+$(eval $(call BuildPackage,libsdl2))
+$(eval $(call BuildPackage,libsdl2-tests))

--- a/libs/sdl2/patches/100-fix-segfault-in-Wayland_DestroyWindow.patch
+++ b/libs/sdl2/patches/100-fix-segfault-in-Wayland_DestroyWindow.patch
@@ -1,0 +1,20 @@
+--- a/src/video/wayland/SDL_waylandwindow.c
++++ b/src/video/wayland/SDL_waylandwindow.c
+@@ -2208,7 +2208,7 @@ void Wayland_DestroyWindow(_THIS, SDL_Wi
+     SDL_VideoData *data = _this->driverdata;
+     SDL_WindowData *wind = window->driverdata;
+ 
+-    if (data) {
++    if (wind) {
+ #ifdef SDL_VIDEO_OPENGL_EGL
+         if (wind->egl_surface) {
+             SDL_EGL_DestroySurface(_this, wind->egl_surface);
+@@ -2256,6 +2256,8 @@ void Wayland_DestroyWindow(_THIS, SDL_Wi
+         wl_surface_destroy(wind->surface);
+ 
+         SDL_free(wind);
++    }
++    if (data) {
+         WAYLAND_wl_display_flush(data->display);
+     }
+     window->driverdata = NULL;


### PR DESCRIPTION
Add everything needed for a classic DOOM experience.

Note that the patch for SDL fixes a segfault issue which has been addressed upstream by libsdl-org/SDL@68d2d9f76d, however the commit is not atomic and only part of the upcoming SDL3 preview.

Required PRs to be merged before:
 * https://github.com/openwrt/packages/pull/25272
 * https://github.com/openwrt/packages/pull/25273
 * https://github.com/openwrt/packages/pull/25274
 * https://github.com/openwrt/video/pull/35