### PR TITLE
assimp: depend on minizip

### DIFF
--- a/libs/assimp/Makefile
+++ b/libs/assimp/Makefile
@@ -23,7 +23,7 @@ define Package/libassimp
   SUBMENU:=Video
   TITLE:=Open Asset Importer Library
   URL:=https://github.com/assimp/assimp
-  DEPENDS:=+libstdcpp +zlib
+  DEPENDS:=+libstdcpp +minizip +zlib
 endef
 
 define Package/libassimp/description


### PR DESCRIPTION
Use minizip-ng from packages feed instead of building in-tree version of minizip.