### PR TITLE
sdl2: build without libunwind

### DIFF
--- a/libs/sdl2/patches/110-tests-no-libunwind.patch
+++ b/libs/sdl2/patches/110-tests-no-libunwind.patch
@@ -1,0 +1,10 @@
+--- a/cmake/sdlchecks.cmake
++++ b/cmake/sdlchecks.cmake
+@@ -1406,7 +1406,4 @@ macro(CheckLibUnwind)
+     endif()
+   endif()
+ 
+-  if(found_libunwind)
+-    set(HAVE_LIBUNWIND_H TRUE)
+-  endif()
+ endmacro()


### PR DESCRIPTION
SDL2 links tests against libunwind if libunwind is detected by CMake. This results in build failure due to undefined symbols. Prevent building with libunwind for now.