### PR TITLE
zmusic: fix target endian detection

### DIFF
--- a/games/zmusic/patches/100-fix-endian-detect-with-musl.patch
+++ b/games/zmusic/patches/100-fix-endian-detect-with-musl.patch
@@ -1,0 +1,11 @@
+--- a/thirdparty/game-music-emu/gme/blargg_endian.h
++++ b/thirdparty/game-music-emu/gme/blargg_endian.h
+@@ -20,7 +20,7 @@
+ // BLARGG_BIG_ENDIAN, BLARGG_LITTLE_ENDIAN: Determined automatically, otherwise only
+ // one may be #defined to 1. Only needed if something actually depends on byte order.
+ #if !defined (BLARGG_BIG_ENDIAN) && !defined (BLARGG_LITTLE_ENDIAN)
+-#ifdef __GLIBC__
++#ifdef __BYTE_ORDER
+ 	// GCC handles this for us
+ 	#include <endian.h>
+ 	#if __BYTE_ORDER == __LITTLE_ENDIAN


### PR DESCRIPTION
Use `__BYTE_ORDER` macro when ever it is defined and not just when using glibc.