### PR TITLE
gzdoom: stage host binaries

### DIFF
--- a/games/gzdoom/Makefile
+++ b/games/gzdoom/Makefile
@@ -48,7 +48,17 @@ endef
 
 define Host/Install
 	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/share/gzdoom
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/re2c/re2c $(STAGING_DIR_HOSTPKG)/share/gzdoom
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/lemon/lemon $(STAGING_DIR_HOSTPKG)/share/gzdoom
+	$(INSTALL_DATA) $(HOST_BUILD_DIR)/tools/lemon/lempar.c $(STAGING_DIR_HOSTPKG)/share/gzdoom
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/zipdir/zipdir $(STAGING_DIR_HOSTPKG)/share/gzdoom
 	$(INSTALL_DATA) $(HOST_BUILD_DIR)/ImportExecutables.cmake $(STAGING_DIR_HOSTPKG)/share/gzdoom
+	$(SED) "s#$(HOST_BUILD_DIR)/tools/re2c/re2c#$(STAGING_DIR_HOSTPKG)/share/gzdoom/re2c#" \
+		$(STAGING_DIR_HOSTPKG)/share/gzdoom/ImportExecutables.cmake
+	$(SED) "s#$(HOST_BUILD_DIR)/tools/lemon/lemon#$(STAGING_DIR_HOSTPKG)/share/gzdoom/lemon#" \
+		$(STAGING_DIR_HOSTPKG)/share/gzdoom/ImportExecutables.cmake
+	$(SED) "s#$(HOST_BUILD_DIR)/tools/zipdir/zipdir#$(STAGING_DIR_HOSTPKG)/share/gzdoom/zipdir#" \
+		$(STAGING_DIR_HOSTPKG)/share/gzdoom/ImportExecutables.cmake
 endef
 
 define Host/Uninstall

--- a/games/gzdoom/patches/120-lzma-pthreads.patch
+++ b/games/gzdoom/patches/120-lzma-pthreads.patch
@@ -2,7 +2,7 @@
 +++ b/libraries/lzma/CMakeLists.txt
 @@ -2,8 +2,6 @@ make_release_only()
  
- set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE -DZ7_PPMD_SUPPORT -D_7ZIP_AFFINITY_DISABLE" )
+ set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE -DZ7_PPMD_SUPPORT -DZ7_AFFINITY_DISABLE" )
  
 -find_package(Threads)
 -


### PR DESCRIPTION
Install host-built binaries to STAGING_DIR_HOSTPKG as HOST_BUILD_DIR gets cleared and should not be referenced after host build has completed.