### PR TITLE
wpewebkit: portability fixes

### DIFF
--- a/libs/wpewebkit/Makefile
+++ b/libs/wpewebkit/Makefile
@@ -38,8 +38,8 @@ CMAKE_OPTIONS += \
 	-DENABLE_SPELLCHECK=OFF \
 	-DENABLE_SPEECH_SYNTHESIS=OFF \
 	-DENABLE_TOUCH_EVENTS=ON \
-	-DENABLE_JIT=ON \
-	-DENABLE_C_LOOP=OFF \
+	-DENABLE_JIT=$(if $(CONFIG_arm_v7)$(CONFIG_aarch64)$(CONFIG_riscv64)$(CONFIG_x86_64),ON,OFF) \
+	-DENABLE_C_LOOP=$(if $(CONFIG_arm_v7)$(CONFIG_aarch64)$(CONFIG_riscv64)$(CONFIG_x86_64),OFF,ON) \
 	-DENABLE_WEBGL=ON \
 	-DENABLE_VIDEO=ON \
 	-DPORT=WPE \
@@ -64,7 +64,8 @@ define Package/libwpewebkit
 	   +libgst1fft +libgst1gl +libgst1pbutils +libgst1tag \
 	   +libgst1transcoder +libgst1video +libinput +libjpeg +libpng \
 	   +libseccomp +libsoup3 +libsqlite3 +libtasn1 +libudev +libwayland \
-	   +libwebp +libwpe +libxml2 +libxslt +zlib
+	   +libwebp +libwpe +libxml2 +libxslt +zlib \
+	   @(arm_v7||i386||i686||ARCH_64BIT)
 endef
 
 define Package/libwpewebkit/description

--- a/libs/wpewebkit/patches/120-PlatformCPU.h-fix-detection-of-PPC-CPU.patch
+++ b/libs/wpewebkit/patches/120-PlatformCPU.h-fix-detection-of-PPC-CPU.patch
@@ -1,0 +1,24 @@
+From 25627ca5cd611bac7f53372c25ab6100f07d7b00 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Mon, 9 Dec 2024 01:50:49 +0000
+Subject: [PATCH] PlatformCPU.h: fix detection of PPC CPU
+
+Detection of PPC CPU currently relies on the CPU(BIG_ENDIAN) which
+is only defined further down in the same header file.
+Directly use byte-order macro just like the PPC64 to fix detection of
+32-bit PPC platforms.
+---
+ Source/WTF/wtf/PlatformCPU.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/Source/WTF/wtf/PlatformCPU.h
++++ b/Source/WTF/wtf/PlatformCPU.h
+@@ -90,7 +90,7 @@
+     || defined(_M_PPC)         \
+     || defined(__PPC))         \
+     && !CPU(PPC64)             \
+-    && CPU(BIG_ENDIAN)
++    && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+ #define WTF_CPU_PPC 1
+ #define WTF_CPU_KNOWN 1
+ #endif

--- a/libs/wpewebkit/patches/121-currentStackPointer-for-Linux-PPC-Linux-PPC64.patch
+++ b/libs/wpewebkit/patches/121-currentStackPointer-for-Linux-PPC-Linux-PPC64.patch
@@ -1,0 +1,31 @@
+From fe687ccb463fa42de923c5440259d89f781f3c69 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Mon, 9 Dec 2024 01:01:44 +0000
+Subject: [PATCH] currentStackPointer for Linux/PPC, Linux/PPC64
+
+Add inline assembly implementation to return the current stack
+pointer on Linux running on PowerPC and PowerPC64 archtecture.
+---
+ Source/WTF/wtf/StackPointer.cpp | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+--- a/Source/WTF/wtf/StackPointer.cpp
++++ b/Source/WTF/wtf/StackPointer.cpp
+@@ -160,6 +160,17 @@ asm (
+      ".previous" "\n"
+ );
+ 
++#elif CPU(PPC) || CPU(PPC64)
++asm (
++    ".text" "\n"
++    ".globl " SYMBOL_STRING(currentStackPointer) "\n"
++    SYMBOL_STRING(currentStackPointer) ":" "\n"
++
++    "mr 3, 1" "\n" // Move stack pointer (r1) to return register (r3)
++    "blr" "\n"     // Branch to link register (return)
++    ".previous" "\n"
++);
++
+ #else
+ #error "Unsupported platform: need implementation of currentStackPointer."
+ #endif

--- a/libs/wpewebkit/patches/122-fix-arm-thumb2-detection.patch
+++ b/libs/wpewebkit/patches/122-fix-arm-thumb2-detection.patch
@@ -1,0 +1,25 @@
+--- a/Source/cmake/OptionsCommon.cmake
++++ b/Source/cmake/OptionsCommon.cmake
+@@ -20,17 +20,17 @@ if (WTF_CPU_ARM)
+     int main() {}
+     ")
+ 
+-    if (COMPILER_IS_CLANG AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
+-        set(CLANG_EXTRA_ARM_ARGS " -mthumb")
++    if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
++        set(EXTRA_ARM_ARGS " -mthumb")
+     endif ()
+ 
+-    set(CMAKE_REQUIRED_FLAGS "${CLANG_EXTRA_ARM_ARGS}")
++    set(CMAKE_REQUIRED_FLAGS "${EXTRA_ARM_ARGS}")
+     CHECK_CXX_SOURCE_COMPILES("${ARM_THUMB2_TEST_SOURCE}" ARM_THUMB2_DETECTED)
+     unset(CMAKE_REQUIRED_FLAGS)
+ 
+     if (ARM_THUMB2_DETECTED AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
+-        string(APPEND CMAKE_C_FLAGS " ${CLANG_EXTRA_ARM_ARGS}")
+-        string(APPEND CMAKE_CXX_FLAGS " ${CLANG_EXTRA_ARM_ARGS}")
++        string(APPEND CMAKE_C_FLAGS " ${EXTRA_ARM_ARGS}")
++        string(APPEND CMAKE_CXX_FLAGS " ${EXTRA_ARM_ARGS}")
+     endif ()
+ endif ()
+ 


### PR DESCRIPTION
 * Use JavaScript JIT only on supported platforms.
 * Fix ARM Thumb2 detection to allow using JavaScript JIT on ARMv7.
 * Add inline assembly implementation returning the current stack pointer on PPC64 (or PPC).