### PR TITLE
mesa: update to version 24.3.1

### DIFF
--- a/libs/mesa/Makefile
+++ b/libs/mesa/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mesa
-PKG_VERSION:=24.3.0
+PKG_VERSION:=24.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://archive.mesa3d.org/
-PKG_HASH:=97813fe65028ef21b4d4e54164563059e8408d8fee3489a2323468d198bf2efc
+PKG_HASH:=9c795900449ce5bc7c526ba0ab3532a22c3c951cab7e0dd9de5fcac41b0843af
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
@@ -725,6 +725,12 @@ define Package/libmesa/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*GL*.so* $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgbm.so* $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgallium*.so* $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/lib/gbm
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/gbm/*.so $(1)/usr/lib/gbm
+	if [ -e "$(PKG_INSTALL_DIR)/usr/lib/dri" ]; then \
+		$(INSTALL_DIR) $(1)/usr/lib/dri ; \
+		$(CP) $(PKG_INSTALL_DIR)/usr/lib/dri/*.so $(1)/usr/lib/dri ; \
+	fi
 	$(INSTALL_DIR) $(1)/usr/share/drirc.d
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/drirc.d/* $(1)/usr/share/drirc.d
 endef

--- a/libs/mesa/patches/100-use-llvm-subproject-vars.patch
+++ b/libs/mesa/patches/100-use-llvm-subproject-vars.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -1743,21 +1743,26 @@ _llvm = get_option('llvm')
+@@ -1748,21 +1748,26 @@ _llvm = get_option('llvm')
  dep_llvm = null_dep
  with_llvm = false
  if _llvm.allowed()
@@ -42,7 +42,7 @@
  endif
  if with_llvm
    pre_args += '-DMESA_LLVM_VERSION_STRING="@0@"'.format(dep_llvm.version())
-@@ -1856,7 +1861,11 @@ endif
+@@ -1861,7 +1866,11 @@ endif
  
  dep_clang = null_dep
  if with_clc or with_gallium_clover


### PR DESCRIPTION
Include libs in /usr/lib/gbm/dri_gbm.so as well as /usr/lib/dri/*.so in libmesa packages.