### PR TITLE
qt6: add initial version for building and packaging base of Qt6

### DIFF
--- a/frameworks/qt6/cmake.mk
+++ b/frameworks/qt6/cmake.mk
@@ -1,0 +1,15 @@
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+# the bin-path should be determined correctly via cmake or qmake queries,
+# but in case scripts call it relying on it in $PATH, add bin/qt6/ to it.
+export PATH:=$(STAGING_DIR_HOSTPKG)/bin/qt6:$(PATH)
+
+CMAKE_OPTIONS += \
+  -DQT_HOST_PATH="$(STAGING_DIR_HOSTPKG)" \
+  -DQT_QMAKE_TARGET_MKSPEC="linux-openwrt-g++"
+
+CMAKE_HOST_OPTIONS += \
+  -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_SKIP_RPATH=FALSE \
+  -DQT_QMAKE_TARGET_MKSPEC="linux-g++"

--- a/frameworks/qt6/common.mk
+++ b/frameworks/qt6/common.mk
@@ -1,0 +1,240 @@
+#
+# Copyright (C) 2020 OpenWrt.org
+# Author: Mirko Vogt <mirko-openwrt@nanl.de>
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+# This file contains Qt specific paths and Install definitions,
+# which are agnostic to whether projects use cmake or qmake.
+# Its main purpose is to provide helper functions for packaging
+# software using Qt.
+
+include $(TOPDIR)/rules.mk
+
+QT_INSTALL_PREFIX:=/usr
+QT_INSTALL_CONFIGURATION:=/etc/qt6
+QT_INSTALL_SYSCONF:=/etc/qt6
+QT_INSTALL_LIBS:=$(QT_INSTALL_PREFIX)/lib
+QT_INSTALL_DATA:=$(QT_INSTALL_PREFIX)/share/qt6
+QT_INSTALL_HEADERS:=$(QT_INSTALL_PREFIX)/include/qt6
+QT_INSTALL_CMAKES:=$(QT_INSTALL_LIBS)/cmake
+QT_INSTALL_PKGCONFIGS:=$(QT_INSTALL_LIBS)/pkgconfig
+QT_INSTALL_BINS:=$(QT_INSTALL_PREFIX)/bin/qt6
+QT_INSTALL_DOCS:=$(QT_INSTALL_DATA)/doc
+QT_INSTALL_TRANSLATIONS:=$(QT_INSTALL_DATA)/translations
+QT_INSTALL_ARCHDATA:=$(QT_INSTALL_LIBS)/qt6
+QT_INSTALL_MKSPECS:=$(QT_INSTALL_ARCHDATA)/mkspecs
+QT_INSTALL_LIBEXECS:=$(QT_INSTALL_ARCHDATA)/libexec
+QT_INSTALL_TESTS:=$(QT_INSTALL_ARCHDATA)/tests
+QT_INSTALL_PLUGINS:=$(QT_INSTALL_ARCHDATA)/plugins
+QT_INSTALL_METATYPES:=$(QT_INSTALL_ARCHDATA)/metatypes
+QT_INSTALL_IMPORTS:=$(QT_INSTALL_ARCHDATA)/imports
+QT_INSTALL_QML:=$(QT_INSTALL_ARCHDATA)/qml
+QT_INSTALL_EXAMPLES:=$(QT_INSTALL_ARCHDATA)/examples
+QT_INSTALL_DEMOS:=$(QT_INSTALL_EXAMPLES)
+
+QT_HOSTPKG_PREFIX:=$(STAGING_DIR_HOSTPKG)
+QT_HOSTPKG_CONFIGURATION:=$(STAGING_DIR_HOSTPKG)/etc/qt6
+QT_HOSTPKG_SYSCONF:=$(STAGING_DIR_HOSTPKG)/etc/qt6
+QT_HOSTPKG_LIBS:=$(QT_HOSTPKG_PREFIX)/lib
+QT_HOSTPKG_DATA:=$(QT_HOSTPKG_PREFIX)/share/qt6
+QT_HOSTPKG_HEADERS:=$(QT_HOSTPKG_PREFIX)/include/qt6
+QT_HOSTPKG_CMAKES:=$(QT_HOSTPKG_LIBS)/cmake
+QT_HOSTPKG_PKGCONFIGS:=$(QT_HOSTPKG_LIBS)/pkgconfig
+QT_HOSTPKG_BINS:=$(QT_HOSTPKG_PREFIX)/bin/qt6
+QT_HOSTPKG_DOCS:=$(QT_HOSTPKG_DATA)/doc
+QT_HOSTPKG_TRANSLATIONS:=$(QT_HOSTPKG_DATA)/translations
+QT_HOSTPKG_ARCHDATA:=$(QT_HOSTPKG_LIBS)/qt6
+QT_HOSTPKG_MKSPECS:=$(QT_HOSTPKG_ARCHDATA)/mkspecs
+QT_HOSTPKG_LIBEXECS:=$(QT_HOSTPKG_ARCHDATA)/libexec
+QT_HOSTPKG_TESTS:=$(QT_HOSTPKG_ARCHDATA)/tests
+QT_HOSTPKG_PLUGINS:=$(QT_HOSTPKG_ARCHDATA)/plugins
+QT_HOSTPKG_METATYPES:=$(QT_HOSTPKG_ARCHDATA)/metatypes
+QT_HOSTPKG_IMPORTS:=$(QT_HOSTPKG_ARCHDATA)/imports
+QT_HOSTPKG_QML:=$(QT_HOSTPKG_ARCHDATA)/qml
+QT_HOSTPKG_EXAMPLES:=$(QT_HOSTPKG_ARCHDATA)/examples
+QT_HOSTPKG_DEMOS:=$(QT_HOSTPKG_EXAMPLES)
+
+# for host builds defined in qmake based target project files (STAGING_DIR)/host
+# defining here instead of qmake.mk to be available to packages without including qmake.mk
+#QT_HOST_PREFIX:=$(STAGING_DIR)/host
+QT_HOST_PREFIX:=$(QT_HOSTPKG_PREFIX)
+#QT_HOST_DATA:=$(QT_HOST_PREFIX)/share/qt6
+QT_HOST_DATA:=$(QT_HOSTPKG_DATA)
+#QT_HOST_BINS:=$(QT_HOST_PREFIX)/bin/qt6
+QT_HOST_BINS:=$(QT_HOSTPKG_BINS)
+#QT_HOST_LIBS:=$(QT_HOST_PREFIX)/lib
+QT_HOST_LIBS:=$(QT_HOSTPKG_LIBS)
+#QT_HOST_LIBEXECS:=$(QT_HOST_LIBS)/qt6/libexec
+QT_HOST_LIBEXECS:=$(QT_HOSTPKG_LIBEXECS)
+
+
+ifeq (qt, $(firstword $(subst 6, ,$(PKG_NAME))))
+# PKG defaults for official Qt modules
+
+PKG_VERSION?=6.9.0
+
+PKG_SOURCE_URL?=https://download.qt.io/official_releases/qt/$(basename $(PKG_VERSION))/$(PKG_VERSION)/submodules
+PKG_SYS_NAME?=$(subst -,,$(subst $(firstword $(subst ., ,$(PKG_VERSION))),,$(PKG_NAME)))
+PKG_SYS_NAME_FULL?=$(PKG_SYS_NAME)-everywhere-src-$(PKG_VERSION)
+PKG_SOURCE?=$(PKG_SYS_NAME_FULL).tar.xz
+
+PKG_LICENSE?=LGPL-3.0-or-commercial
+
+PKG_BUILD_DIR?=$(BUILD_DIR)/$(PKG_SYS_NAME_FULL)
+HOST_BUILD_DIR?=$(BUILD_DIR_HOST)/$(PKG_SYS_NAME_FULL)
+
+PKG_BUILD_PARALLEL?=1
+HOST_BUILD_PARALLEL?=1
+PKG_BUILD_FLAGS?=no-mips16
+
+PKG_INSTALL?=1
+endif
+
+
+define Build/Install/Headers
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_HEADERS)
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_HEADERS)/* \
+		$(1)/$(QT_INSTALL_HEADERS)/
+endef
+
+define Build/Install/Cmakes
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_CMAKES)
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_CMAKES)/* \
+		$(1)/$(QT_INSTALL_CMAKES)/
+endef
+
+define Build/Install/Pkgconfigs
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_PKGCONFIGS)
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_PKGCONFIGS)/* \
+		$(1)/$(QT_INSTALL_PKGCONFIGS)/
+endef
+
+define Build/Install/Libs_shared
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_LIBS)/$(dir $(2))
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_LIBS)/$(2).so* \
+		$(1)/$(QT_INSTALL_LIBS)/$(dir $(2))/
+endef
+
+define Build/Install/Libs_static
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_LIBS)/$(dir $(2))
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_LIBS)/$(2).a \
+		$(1)/$(QT_INSTALL_LIBS)/$(dir $(2))/
+endef
+
+define Build/Install/Libs
+	$(call Build/Install/Libs_shared,$(1),$(2))
+endef
+
+define Build/Install/Archdata
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_ARCHDATA)
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_ARCHDATA)/* \
+		$(1)/$(QT_INSTALL_ARCHDATA)/
+endef
+
+define Build/Install/Data
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_DATA)
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_DATA)/* \
+		$(1)/$(QT_INSTALL_DATA)/
+endef
+
+define Build/Install/Mkspecs
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_MKSPECS)/$(dir $(2))
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_MKSPECS)/$(2) \
+		$(1)/$(QT_INSTALL_MKSPECS)/$(dir $(2))/
+endef
+
+define Build/Install/Metatypes
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_METATYPES)/$(dir $(2))
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_METATYPES)/$(2).json \
+		$(1)/$(QT_INSTALL_METATYPES)/$(dir $(2))/
+endef
+
+define Build/Install/Translations
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_TRANSLATIONS)/$(dir $(2))
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_TRANSLATIONS)/$(2).qm \
+		$(1)/$(QT_INSTALL_TRANSLATIONS)/$(dir $(2))/
+endef
+
+define Build/Install/Plugins
+	if [ "$(2)" = '*' ]; then \
+		$(INSTALL_DIR) \
+			$(1)/$(QT_INSTALL_PLUGINS) ; \
+		$(CP) \
+			$(PKG_INSTALL_DIR)/$(QT_INSTALL_PLUGINS)/$(2) \
+			$(1)/$(QT_INSTALL_PLUGINS)/ ; \
+	else \
+		$(INSTALL_DIR) \
+			$(1)/$(QT_INSTALL_PLUGINS)/$(2) ; \
+		$(CP) \
+			$(PKG_INSTALL_DIR)/$(QT_INSTALL_PLUGINS)/$(2)/$(3).so* \
+			$(1)/$(QT_INSTALL_PLUGINS)/$(2)/ ; \
+	fi
+endef
+
+define Build/Install/Examples
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_EXAMPLES)
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/$(QT_INSTALL_EXAMPLES)/* \
+		$(1)/$(QT_INSTALL_EXAMPLES)/
+
+	$(FIND) $(1)/$(QT_INSTALL_EXAMPLES) \
+		-type f \( -name '*.cpp' -o -name '*.h' -o -name '*.pro' -o -name '*.pri' \) | \
+		$(XARGS) $(RM) -vf
+endef
+
+define Build/Install/QMLplugin
+	$(INSTALL_DIR) \
+		$(1)/$(QT_INSTALL_QML)/$(2)
+
+	$(CP) \
+	  $(PKG_INSTALL_DIR)/$(QT_INSTALL_QML)/$(2)/{plugins.qmltypes,qmldir,$(3).{so,qml,js}} \
+	  $(1)/$(QT_INSTALL_QML)/$(2)/ \
+	  || true
+endef
+
+###
+
+define Build/InstallDev/Qt
+	$(call Build/Install/Headers,$(1)) || true
+	$(call Build/Install/Cmakes,$(1)) || true
+	$(call Build/Install/Pkgconfigs,$(1)) || true
+	$(call Build/Install/Mkspecs,$(1),*) || true
+	$(call Build/Install/Libs_shared,$(1),*) || true
+	$(call Build/Install/Libs_static,$(1),*) || true
+	$(call Build/Install/Archdata,$(1)) || true
+	$(call Build/Install/Data,$(1)) || true
+endef

--- a/frameworks/qt6/qmake.mk
+++ b/frameworks/qt6/qmake.mk
@@ -1,0 +1,122 @@
+#
+# Copyright (C) 2020 OpenWrt.org
+# Author: Mirko Vogt <mirko-openwrt@nanl.de>
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+# qmake - oh my.. qmake is supposed to generate Makefiles suitable for cross-compiling
+# however fails itself hard being used in a cross compiling toolchain in any sane way.
+# 
+# There are the QT_INSTALL_* variables - which get set via Qt's configure options,
+# containing paths which become hardcoded into the qmake binary.
+# Those paths are supposed to refer to the target system, however are also used for
+# include and linker paths.
+# Hence, setting QT_INSTALL_PREFIX=/usr would result in -I/usr/include,
+# -L/usr/lib, etc., referencing the host headers and libraries.
+# The QT_SYSROOT variable looks most promising for distinguishing between
+# host and target specific paths, however it fails hard and is totally undocumented.
+# The extprefix variable tries to cover the situation, however actually just prepends
+# its path to the QT_INSTALL_* variables - basically cosmetics.
+# 
+# The QT_HOST_* variables are used for host tools, libraries, mkspecs and its data.
+# 
+# As a consequence we set QT_INSTALL_* and QT_HOST_* to absolute paths, which
+# inevitably results in the following issues:
+# 
+#  - 'make install' results in paths like:
+#    /tmp/install_root/home/cross/openwrt/staging_dir/target-*/usr.
+#    This is workarounded by overriding the PKG_INSTALL_DIR, so the Makefiles don't
+#    have to care about that.
+#  - Once compiled, qmake's location and its requirements (mkspecs, etc.) are fixed,
+#    since its absolute paths were hardcoded. No moving around of the toolchain.
+#  - Those variables might be used for target binaries for some weird reason, so
+#    paths to the host staging_dir would make it to the target, logically leading to
+#    errors.
+#  - Paths might make it into target binaries, thus referencing non-existing
+#    objects on the target platform. Tihs behaviour wasn't observed so far, however 
+#    one might use the QT_INSTALL_* variables for some weird reason during runtime.
+
+
+include $(TOPDIR)/rules.mk
+
+QMAKE_SPEC:=linux-openwrt-host-g++
+QMAKE_XSPEC:=linux-openwrt-g++
+
+QMAKE_TARGET=$(STAGING_DIR)/host/bin/qt6/qmake # host exe used for target specific builds
+QMAKE_HOST=$(QT_HOST_BINS)/qmake # host exe used for host builds
+
+define Build/Configure/Default
+	TARGET_CROSS="$(TARGET_CROSS)" \
+	TARGET_CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
+	TARGET_CXXFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CXXFLAGS)" \
+	TARGET_LDFLAGS="$(TARGET_LDFLAGS)" \
+	$(QMAKE_TARGET) \
+		-o $(PKG_BUILD_DIR)/$(MAKE_PATH)/Makefile \
+		$(PKG_BUILD_DIR)/$(MAKE_PATH)/$(if $(1),$(1).pro,)
+endef
+
+define Host/Configure/Default
+	$(QMAKE_HOST) \
+		-o $(HOST_BUILD_DIR)/$(MAKE_PATH)/Makefile \
+		$(HOST_BUILD_DIR)/$(MAKE_PATH)/$(if $(1),$(1).pro,)
+endef
+
+# We need to pass all qmake (TARGET_*) related variables to $(MAKE) as well, as
+# (generated) Makefiles may invoke qmake once again for creating further Makefiles.
+# Actually we'd also like to pass all other vars (defined in $MAKE_VARS and
+# $MAKE_FLAGS) to also make ordinary non-qmake generated Makefiles calling tool-
+# chain executables like $CC/$CXX/$AR.. work, however this would interfere with
+# qmake generated Makefiles, since they expect variables being set differently.
+# For example qmake generated Makefiles expect $AR to also contain ar's arguments,
+# while ordinary Makefiles don't.
+# Until we find a way to disginguish both kinds of Makefiles, we will neglect
+# ordinary Makefiles calling toolchain executables, however as they might take
+# $CFLAGS/CXXFLAGS into account (e.g. flags as -D*), we pass at least those
+# hoping to not interfere / break something.
+# Mixing qmake generated and ordinary Makfiles - both calling toolchain execut-
+# ables - is probably a very rare case anyway.
+define Build/Compile/Default
+	+TARGET_CROSS="$(TARGET_CROSS)" \
+	TARGET_CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
+	TARGET_CXXFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CXXFLAGS)" \
+	TARGET_LDFLAGS="$(TARGET_LDFLAGS)" \
+	CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
+	CXXFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CXXFLAGS)" \
+	LDFLAGS="$(TARGET_LDFLAGS)" \
+		$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/$(MAKE_PATH) \
+			$(1)
+endef
+
+define Host/Compile/Default
+	$(MAKE) $(PKG_JOBS) -C $(HOST_BUILD_DIR)/$(MAKE_PATH) \
+		$(1)
+endef
+
+define Build/Install/Default
+	INSTALL_ROOT="$(PKG_INSTALL_DIR)/.owrttmp" \
+		$(MAKE) -C $(PKG_BUILD_DIR)/$(MAKE_PATH) \
+			$(1) install
+	mv "$(PKG_INSTALL_DIR)/.owrttmp/$(STAGING_DIR)/"* \
+		$(PKG_INSTALL_DIR)/ && \
+		rm -r $(PKG_INSTALL_DIR)/.owrttmp
+endef
+
+define Host/Install/Default
+	INSTALL_ROOT="$(HOST_INSTALL_DIR)/.owrttmp" \
+		$(MAKE) -C $(HOST_BUILD_DIR)/$(MAKE_PATH) \
+			$(1) install
+	mv "$(HOST_INSTALL_DIR)/.owrttmp/$(STAGING_DIR_HOST)/"* \
+		$(HOST_INSTALL_DIR)/ && \
+		rm -r "$(HOST_INSTALL_DIR)/.owrttmp"
+endef
+
+# target specific host builds triggered by target qmake runs
+define Build/Install/HostFiles
+	$(INSTALL_DIR) \
+		$(STAGING_DIR)/host
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/host/* \
+		$(STAGING_DIR)/host/
+endef

--- a/frameworks/qt6/qt6base/Config_qt6base-core.in
+++ b/frameworks/qt6/qt6base/Config_qt6base-core.in
@@ -1,0 +1,6 @@
+config BUILD_qt6base-core_INOTIFY
+    bool "Use native inotify support on Linux"
+    depends on PACKAGE_qt6base-core
+    default y
+    help
+        "Compiles Qt's QFileSystemWatcher with support for inotify on Linux. Otherwise QFileSystemWatcher uses polling as fallback."

--- a/frameworks/qt6/qt6base/Config_qt6base-gui.in
+++ b/frameworks/qt6/qt6base/Config_qt6base-gui.in
@@ -1,0 +1,22 @@
+config BUILD_qt6base-gui_DRM
+    bool "Include DRM support"
+    #depends on PACKAGE_qt6base-gui
+    default y
+
+config BUILD_qt6base-gui_ICU
+    bool "Compile with ICU internationalization support"
+    #depends on PACKAGE_qt6base-gui
+    default y
+
+choice
+    prompt "Which OpenGL variant to use"
+    default BUILD_qt6base-gui_OPENGL_NONE
+    #depends on PACKAGE_qt6base-gui
+
+config BUILD_qt6base-gui_OPENGL_OPENGLES2
+    bool "es2"
+
+config BUILD_qt6base-gui_OPENGL_NONE
+    bool "no"
+
+endchoice

--- a/frameworks/qt6/qt6base/Config_qt6base-network.in
+++ b/frameworks/qt6/qt6base/Config_qt6base-network.in
@@ -1,0 +1,4 @@
+config BUILD_qt6base-network_SSL
+    bool "Include native SSL support (OpenSSL)"
+    depends on PACKAGE_qt6base-network
+    default y

--- a/frameworks/qt6/qt6base/Makefile
+++ b/frameworks/qt6/qt6base/Makefile
@@ -1,0 +1,671 @@
+#
+# Copyright (C) 2020 OpenWrt.org
+# Author: Mirko Vogt <mirko-openwrt@nanl.de>
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+# some parts of the journey documented here:
+# https://bugreports.qt.io/browse/QTBUG-136244
+# https://bugreports.qt.io/browse/QTBUG-136582
+# https://bugreports.qt.io/browse/QTBUG-136446
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=qt6base
+PKG_RELEASE:=1
+PKG_HASH:=skip
+
+include ../common.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/nls.mk
+include ../cmake.mk
+
+PKG_CONFIG_DEPENDS:= \
+  CONFIG_BUILD_qt6base-core_INOTIFY \
+  CONFIG_BUILD_qt6base-gui_DRM \
+  CONFIG_BUILD_qt6base-gui_ICU \
+  CONFIG_BUILD_qt6base-gui_OPENGL_NONE \
+  CONFIG_BUILD_qt6base-gui_OPENGL_OPENGLES2 \
+  CONFIG_BUILD_qt6base-network_SSL \
+  CONFIG_PACKAGE_qt6base-gui \
+  CONFIG_PACKAGE_qt6base-widgets \
+  CONFIG_PACKAGE_qt6base-plugin-platforms-linuxfb \
+  CONFIG_PACKAGE_qt6base-plugin-platforms-vnc \
+  CONFIG_PACKAGE_qt6base-plugin-input-libinput
+
+HOST_BUILD_DEPENDS:=pcre2/host
+PKG_BUILD_DEPENDS:=qt6base/host
+
+# Do not use sstrip for Qt6. When sstrip is used, Qt6 plugin loading
+# does not work, because of Qt's internal elf parser, see:
+# https://bugreports.qt.io/browse/QTBUG-52567
+# Use code copied from the gcc package to use stripping instead.
+ifneq ($(CONFIG_USE_SSTRIP),)
+  STRIP:=$(TARGET_CROSS)strip $(call qstrip,$(CONFIG_STRIP_ARGS))
+  RSTRIP:= \
+    export CROSS="$(TARGET_CROSS)" \
+		$(if $(CONFIG_KERNEL_KALLSYMS),NO_RENAME=1) \
+		$(if $(CONFIG_KERNEL_PROFILING),KEEP_SYMBOLS=1); \
+    NM="$(TARGET_CROSS)nm" \
+    STRIP="$(STRIP)" \
+    STRIP_KMOD="$(SCRIPT_DIR)/strip-kmod.sh" \
+    $(SCRIPT_DIR)/rstrip.sh
+endif
+
+define Package/qt6base/Default
+  SECTION:=video-frameworks
+  CATEGORY:=Video
+  SUBMENU:=Frameworks and Toolkits
+  TITLE:=Qt6base
+  DEPENDS:=
+  URL:=http://qt.io
+  MAINTAINER:=Mirko Vogt <mirko-openwrt@nanl.de>
+endef
+
+define Package/qt6base-concurrent
+  $(call Package/qt6base/Default)
+  TITLE+=concurrent
+  DEPENDS+=+qt6base-core
+endef
+
+define Package/qt6base-core
+  $(call Package/qt6base/Default)
+  TITLE+=core
+    DEPENDS+=+zlib +libzstd +libstdcpp +libpcre2-16 +libdouble-conversion $(ICONV_DEPENDS) +BUILD_qt6base-gui_ICU:icu #FIXME: do not include ICONV_DEPENDS if ICU is selected (though, that's only an issue when using GNU iconv)
+
+endef
+
+define Package/qt6base-core/config
+        source "$(SOURCE)/Config_qt6base-core.in"
+endef
+
+define Package/qt6base-gui
+  $(call Package/qt6base/Default)
+  TITLE+=gui
+  DEPENDS+=+qt6base-core +libpng +libfreetype +BUILD_qt6base-gui_OPENGL_OPENGLES2:libmesa # +BUILD_qt6base-gui_OPENGL_OPENGLES2:qt6base-widgets # qt6base-widgets appears to be needed when compiled with gl support, otherwise unneeded
+
+endef
+
+define Package/qt6base-gui/config
+        source "$(SOURCE)/Config_qt6base-gui.in"
+endef
+
+define Package/qt6base-network
+  $(call Package/qt6base/Default)
+  TITLE+=network
+  DEPENDS+=+qt6base-core +BUILD_qt6base-network_SSL:libopenssl
+endef
+
+define Package/qt6base-network/config
+        source "$(SOURCE)/Config_qt6base-network.in"
+endef
+
+#define Package/qt6base-printSupport
+#  $(call Package/qt6base/Default)
+#  TITLE+=print support
+#  DEPENDS+=+qt6base-core +qt6base-gui +qt6base-widgets
+#endef
+#
+#define Package/qt6base-sql
+#  $(call Package/qt6base/Default)
+#  TITLE+=sql
+#  DEPENDS+=+qt6base-core
+#endef
+
+define Package/qt6base-test
+  $(call Package/qt6base/Default)
+  TITLE+=test
+  DEPENDS+=+qt6base-core
+endef
+
+define Package/qt6base-widgets
+  $(call Package/qt6base/Default)
+  TITLE+=widgets
+  DEPENDS+=+qt6base-gui
+endef
+
+define Package/qt6base-openglwidgets
+  $(call Package/qt6base/Default)
+  TITLE+=widgets
+  DEPENDS+=+qt6base-opengl +qt6base-widgets @BUILD_qt6base-gui_OPENGL_OPENGLES2
+endef
+
+define Package/qt6base-xml
+  $(call Package/qt6base/Default)
+  TITLE+=xml
+  DEPENDS+=+qt6base-core
+endef
+
+define Package/qt6base-opengl
+  $(call Package/qt6base/Default)
+  TITLE+=opengl
+  DEPENDS+=+qt6base-gui +libudev +libmesa @BUILD_qt6base-gui_OPENGL_OPENGLES2 # EglFSDeviceIntegration, EglFsKmsGbmSupport and EglFsKmsSupport are linked against libudev
+endef
+
+#### plugins
+
+####### bearer
+
+define Package/qt6base-plugin-bearer-generic
+  $(call Package/qt6base/Default)
+TITLE+=bearer (plugin)
+  DEPENDS+=+qt6base-core +qt6base-network
+endef
+
+####### generic / input
+
+define Package/qt6base-plugin-input-libinput
+  $(call Package/qt6base/Default)
+  TITLE+=libinput (plugin)
+  DEPENDS+=+qt6base-core +qt6base-gui +libinput
+endef
+
+define Package/qt6base-plugin-input-evdevkeyboard
+  $(call Package/qt6base/Default)
+  TITLE+=evdev keyboard (plugin)
+  DEPENDS+=+qt6base-core +qt6base-gui +libudev +PACKAGE_qt6base-plugin-input-libinput:libinput
+endef
+
+define Package/qt6base-plugin-input-evdevmouse
+  $(call Package/qt6base/Default)
+  TITLE+=evdev mouse (plugin)
+  DEPENDS+=+qt6base-core +qt6base-gui +libudev +PACKAGE_qt6base-plugin-input-libinput:libinput
+endef
+
+define Package/qt6base-plugin-input-evdevtablet
+  $(call Package/qt6base/Default)
+  TITLE+=evdev tablet (plugin)
+  DEPENDS+=+qt6base-core +qt6base-gui +libudev +PACKAGE_qt6base-plugin-input-libinput:libinput
+endef
+
+define Package/qt6base-plugin-input-evdevtouch
+  $(call Package/qt6base/Default)
+  TITLE+=evdev touch (plugin)
+  DEPENDS+=+qt6base-core +qt6base-gui +libudev +PACKAGE_qt6base-plugin-input-libinput:libinput
+endef
+
+####### imageformats
+
+#define Package/qt6base-plugin-imageformats-gif
+#  $(call Package/qt6base/Default)
+#TITLE+=imageformat gif (plugin)
+#  DEPENDS+=+qt6base-core +qt6base-gui
+#endef
+
+define Package/qt6base-plugin-imageformats-ico
+  $(call Package/qt6base/Default)
+  TITLE+=imageformat ico (plugin)
+  DEPENDS+=+qt6base-core +qt6base-gui
+endef
+
+define Package/qt6base-plugin-imageformats-jpeg
+  $(call Package/qt6base/Default)
+  TITLE+=imageformat jpeg (plugin)
+  DEPENDS+=+qt6base-core +qt6base-gui +libjpeg
+endef
+
+define Package/qt6base-plugin-imageformats-png
+  $(call Package/qt6base/Default)
+  TITLE+=imageformat png (plugin)
+  DEPENDS+=+qt6base-core +qt6base-gui +libpng
+endef
+
+####### platforms
+
+define Package/qt6base-plugin-platforms-minimal
+  $(call Package/qt6base/Default)
+  TITLE+=platform minimal (plugin)
+  DEPENDS+=+qt6base-gui
+endef
+
+define Package/qt6base-plugin-platforms-offscreen
+  $(call Package/qt6base/Default)
+  TITLE+=platform offscreen (plugin)
+  DEPENDS+=+qt6base-gui
+endef
+
+define Package/qt6base-plugin-platforms-linuxfb
+  $(call Package/qt6base/Default)
+  TITLE+=platform linuxfb (plugin)
+  DEPENDS+=+qt6base-core +qt6base-gui +libudev +PACKAGE_qt6base-plugin-input-libinput:libinput
+endef
+
+define Package/qt6base-plugin-platforms-vnc
+  $(call Package/qt6base/Default)
+  TITLE+=platform vnc (plugin)
+  DEPENDS+=+qt6base-core +qt6base-gui +qt6base-network +libfreetype +libudev +PACKAGE_qt6base-plugin-input-libinput:libinput
+endef
+
+define Package/qt6base-plugin-platforms-minimalegl
+  $(call Package/qt6base/Default)
+  TITLE+=platform minimalegl (plugin)
+  DEPENDS+=+qt6base-gui +qt6base-opengl
+endef
+
+define Package/qt6base-plugin-platforms-eglfs
+  $(call Package/qt6base/Default)
+  TITLE+=platform eglfs (plugin)
+  DEPENDS+=+qt6base-gui +qt6base-opengl +libudev # +qt6base-eglfs-device-integration
+endef
+
+
+###### sql
+
+#define Package/qt6base-plugin-sqldrivers-sqlite
+#  $(call Package/qt6base/Default)
+#  TITLE+=sqldriver sqlite (plugin)
+#  DEPENDS+=+qt6base-core +qt6base-sql +libsqlite3
+#endef
+
+define Package/qt6base-examples
+  $(call Package/qt6base/Default)
+  TITLE+=examples
+  DEPENDS+=\
+	+qt6base-core \
+	+qt6base-gui \
+	+qt6base-widgets \
+	+qt6base-network \
+	+qt6base-sql \
+	+qt6base-xml \
+	+qt6base-printSupport \
+	+qt6base-concurrent \
+	+qt6base-gl
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	# building qt6base for the target requires mkspecs in the target staging-dir, see:
+	# https://bugreports.qt.io/browse/QTBUG-136244
+	$(CP) \
+	  ./files/mkspecs/* \
+	  $(PKG_BUILD_DIR)/mkspecs/
+endef
+
+define Host/Prepare
+	$(call Host/Prepare/Default)
+	# qmake6 looks for mkspecs inside QT_HOST_DATA / HostData - even for target builds
+	$(CP) \
+	  ./files/mkspecs/* \
+	  $(HOST_BUILD_DIR)/mkspecs/
+endef
+
+# mkspecs are not actually used/read when compiling via cmake,
+# but at least the respective mkspec-dir still needs to be present.
+# cmake-qt.mk defines linux-openwrt-g++ as mkspec, which eventually
+# needs to be present in the *target*-staging-dir for other modules
+# to find and include it.
+# qt6base itself, though, expects all custom mkspecs to present in
+# its own source dir.
+CMAKE_OPTIONS += \
+	-DINSTALL_PREFIX=$(QT_INSTALL_PREFIX) \
+	-DINSTALL_ARCHDATADIR=$(QT_INSTALL_ARCHDATA) \
+	-DINSTALL_BINDIR=$(QT_INSTALL_BINS) \
+	-DINSTALL_DATADIR=$(QT_INSTALL_DATA) \
+	-DINSTALL_DOCDIR=$(QT_INSTALL_DOCS) \
+	-DINSTALL_EXAMPLESDIR=$(QT_INSTALL_EXAMPLES) \
+	-DINSTALL_INCLUDEDIR=$(QT_INSTALL_HEADERS) \
+	-DINSTALL_LIBDIR=$(QT_INSTALL_LIBS) \
+	-DINSTALL_LIBEXECDIR=$(QT_INSTALL_LIBEXECS) \
+	-DINSTALL_PLUGINSDIR=$(QT_INSTALL_PLUGINS) \
+	-DINSTALL_QMLDIR=$(QT_INSTALL_QML) \
+	-DINSTALL_SYSCONFDIR=$(QT_INSTALL_SYSCONF) \
+	-DINSTALL_TESTSDIR=$(QT_INSTALL_TESTS) \
+	-DINSTALL_TRANSLATIONDIR=$(QT_INSTALL_TRANSLATIONS) \
+	-DINSTALL_MKSPECSDIR=$(QT_INSTALL_MKSPECS) \
+	-DQT_BUILD_TESTS_PROJECT_all=OFF \
+	-DQT_BUILD_EXAMPLES_PROJECT_all=OFF \
+	-DBUILD_WITH_PCH=OFF \
+	-DQT_USE_CCACHE=OFF \
+	-DQT_USE_VCPKG=OFF \
+	-DQT_BUILD_EXAMPLES=FALSE \
+	-DQT_BUILD_TESTS=FALSE \
+	-DFEATURE_optimize_size=ON \
+	-DFEATURE_reduce_exports=OFF \
+	-DFEATURE_reduce_relocations=OFF \
+	-DQT_GENERATE_SBOM=OFF \
+	-DFEATURE_intelcet=OFF \
+	-DFEATURE_stack_protector=OFF \
+	-DFEATURE_stack_clash_protection=OFF \
+	-DFEATURE_libstdcpp_assertions=OFF \
+	-DINPUT_linker=bfd \
+	-DFEATURE_pkg_config=ON \
+	-DFEATURE_gui=$(if $(CONFIG_PACKAGE_qt6base-gui),ON,OFF) \
+	-DFEATURE_widgets=$(if $(CONFIG_PACKAGE_qt6base-widgets),ON,OFF) \
+	-DFEATURE_dbus=OFF \
+	-DFEATURE_accessibility=ON \
+	-DINPUT_doubleconversion=qt \
+	-DFEATURE_glib=OFF \
+	-DFEATURE_inotify=$(if $(CONFIG_BUILD_qt6base-core_INOTIFY),ON,OFF) \
+	-DFEATURE_icu=$(if $(CONFIG_BUILD_qt6base-gui_ICU),ON,OFF) \
+	-DINPUT_pcre=system \
+	-DFEATURE_system_zlib=ON \
+	-DFEATURE_journald=OFF \
+	-DFEATURE_syslog=OFF \
+	-DFEATURE_ssl=$(if $(CONFIG_BUILD_qt6base-network_SSL),ON,OFF) \
+	-DINPUT_openssl=$(if $(CONFIG_BUILD_qt6base-network_SSL),linked,OFF) \
+	-DFEATURE_sctp=OFF \
+	-DFEATURE_libproxy=OFF \
+	-DFEATURE_system_proxies=ON \
+	-DFEATURE_cups=OFF \
+	-DFEATURE_emojisegmenter=OFF \
+	-DFEATURE_fontconfig=OFF \
+	-DINPUT_freetype=system \
+	-DINPUT_harfbuzz=no \
+	-DFEATURE_gtk3=OFF \
+	-DINPUT_opengl=$(if $(CONFIG_BUILD_qt6base-gui_OPENGL_OPENGLES2),es2,no) \
+	-DFEATURE_egl=$(if $(CONFIG_BUILD_qt6base-gui_OPENGL_OPENGLES2),ON,OFF) \
+	-DQT_QPA_PLATFORMS=$(if $(CONFIG_PACKAGE_qt6base-plugin-platforms-linuxfb),linuxfb,) \
+	-DQT_QPA_DEFAULT_PLATFORM=$(if $(CONFIG_PACKAGE_qt6base-plugin-platforms-linuxfb),linuxfb,) \
+	-DFEATURE_directfb=OFF \
+	-DFEATURE_eglfs=$(if $(CONFIG_BUILD_qt6base-gui_OPENGL_OPENGLES2),ON,OFF) \
+	-DFEATURE_gbm=$(if $(CONFIG_BUILD_qt6base-gui_DRM),ON,OFF) \
+	-DFEATURE_kms=$(if $(CONFIG_BUILD_qt6base-gui_DRM),ON,OFF) \
+	-DFEATURE_linuxfb=$(if $(CONFIG_PACKAGE_qt6base-plugin-platforms-linuxfb),ON,OFF) \
+	-DFEATURE_vnc=$(if $(CONFIG_PACKAGE_qt6base-plugin-platforms-vnc),ON,OFF) \
+	-DFEATURE_xcb=OFF \
+	-DFEATURE_libudev=ON \
+	-DFEATURE_evdev=ON \
+	-DFEATURE_libinput=$(if $(CONFIG_PACKAGE_qt6base-plugin-input-libinput),ON,OFF) \
+	-DFEATURE_mtdev=OFF \
+	-DFEATURE_tslib=OFF \
+	-DFEATURE_xkbcommon=OFF \
+	-DFEATURE_gif=ON \
+	-DFEATURE_ico=OFF \
+	-DINPUT_libpng=system \
+	-DINPUT_libjpeg=system \
+	-DFEATURE_sql=OFF \
+	-DFEATURE_sqlmodel=OFF
+
+
+#HOST_LDFLAGS += -L$(HOST_BUILD_DIR) # otherwise local executables can't find local shared objects
+
+# BUILD_SHARED_LIBS=ON needed for host in order for qtdeclarative/host building correctly with BUILD_SHARED_LIBS=ON which is needed for qtshaders/host building the actual host tools (as bin/qsb, which it doesn't if built statically), eventually needed for building qtdeclarative for the target
+# FEATURE_gui=ON for host build required in order to build qt6shadertools for host
+# CMAKE_SKIP_RPATH=FALSE otherwise host tools won't be able to load shared objects not in system paths (in this case, build_dir/qtbase-*/lib/Qt6Core.so)
+#
+# files/dirs within most install-paths are properly versioned and can be distinguished among versions (e.g. qt5 and qt6). some are not, though, and will bet set to version specifics explicitly
+CMAKE_HOST_OPTIONS += \
+	-DINSTALL_PREFIX=$(QT_HOSTPKG_PREFIX) \
+	-DINSTALL_ARCHDATADIR=$(QT_HOSTPKG_ARCHDATA) \
+	-DINSTALL_BINDIR=$(QT_HOSTPKG_BINS) \
+	-DINSTALL_DATADIR=$(QT_HOSTPKG_DATA) \
+	-DINSTALL_DOCDIR=$(QT_HOSTPKG_DOCS) \
+	-DINSTALL_EXAMPLESDIR=$(QT_HOSTPKG_EXAMPLES) \
+	-DINSTALL_INCLUDEDIR=$(QT_HOSTPKG_HEADERS) \
+	-DINSTALL_LIBDIR=$(QT_HOSTPKG_LIBS) \
+	-DINSTALL_LIBEXECDIR=$(QT_HOSTPKG_LIBEXECS) \
+	-DINSTALL_PLUGINSDIR=$(QT_HOSTPKG_PLUGINS) \
+	-DINSTALL_QMLDIR=$(QT_HOSTPKG_QML) \
+	-DINSTALL_SYSCONFDIR=$(QT_HOSTPKG_SYSCONF) \
+	-DINSTALL_TESTSDIR=$(QT_HOSTPKG_TESTS) \
+	-DINSTALL_TRANSLATIONDIR=$(QT_HOSTPKG_TRANSLATIONS) \
+	-DINSTALL_MKSPECSDIR=$(QT_HOSTPKG_MKSPECS) \
+	-DCMAKE_SKIP_RPATH=FALSE  \
+	-DQT_BUILD_TESTS_PROJECT_all=OFF \
+	-DQT_BUILD_EXAMPLES_PROJECT_all=OFF \
+	-DBUILD_WITH_PCH=ON \
+	-DQT_USE_CCACHE=OFF \
+	-DQT_USE_VCPKG=OFF \
+	-DQT_BUILD_EXAMPLES=FALSE \
+	-DQT_BUILD_TESTS=FALSE \
+	-DFEATURE_optimize_size=ON \
+	-DFEATURE_reduce_exports=OFF \
+	-DFEATURE_reduce_relocations=OFF \
+	-DQT_GENERATE_SBOM=OFF \
+	-DFEATURE_intelcet=OFF \
+	-DFEATURE_stack_protector=OFF \
+	-DFEATURE_stack_clash_protection=OFF \
+	-DFEATURE_libstdcpp_assertions=OFF \
+	-DINPUT_linker=bfd \
+	-DFEATURE_pkg_config=ON \
+	-DFEATURE_gui=ON \
+	-DFEATURE_widgets=OFF \
+	-DFEATURE_dbus=OFF \
+	-DFEATURE_accessibility=OFF \
+	-DINPUT_doubleconversion=no \
+	-DFEATURE_glib=OFF \
+	-DFEATURE_inotify=OFF \
+	-DFEATURE_icu=OFF \
+	-DINPUT_pcre=ON \
+	-DFEATURE_system_zlib=ON \
+	-DFEATURE_journald=OFF \
+	-DFEATURE_syslog=OFF \
+	-DFEATURE_ssl=OFF \
+	-DINPUT_openssl=no \
+	-DFEATURE_sctp=OFF \
+	-DFEATURE_libproxy=OFF \
+	-DFEATURE_system_proxies=ON \
+	-DFEATURE_cups=OFF \
+	-DFEATURE_emojisegmenter=OFF \
+	-DFEATURE_fontconfig=OFF \
+	-DINPUT_freetype=no \
+	-DINPUT_harfbuzz=no \
+	-DFEATURE_gtk3=OFF \
+	-DINPUT_opengl=no \
+	-DFEATURE_egl=OFF \
+	-DFEATURE_directfb=OFF \
+	-DFEATURE_eglfs=OFF \
+	-DFEATURE_gbm=OFF \
+	-DFEATURE_kms=OFF \
+	-DFEATURE_linuxfb=OFF \
+	-DFEATURE_xcb=OFF \
+	-DFEATURE_libudev=OFF \
+	-DFEATURE_evdev=OFF \
+	-DFEATURE_libinput=OFF \
+	-DFEATURE_mtdev=OFF \
+	-DFEATURE_tslib=OFF \
+	-DFEATURE_xkbcommon=OFF \
+	-DFEATURE_gif=OFF \
+	-DFEATURE_ico=OFF \
+	-DINPUT_libpng=no \
+	-DINPUT_libjpeg=no \
+	-DFEATURE_sql=OFF \
+	-DFEATURE_sqlmodel=OFF
+
+#define Host/Install
+#	$(call Host/Install/Default)
+#
+#	$(INSTALL_DIR) \
+#	  $(QT_HOST_DATA)/mk
+#
+#	$(CP) \
+#	  ./files/qt.mk \
+#	  $(QT_HOST_DATA)/mk/qt.mk
+#
+#	$(CP) \
+#	  ./files/qmake.mk \
+#	  $(QT_HOST_DATA)/mk/qmake.mk
+#
+#	$(CP) \
+#	  ./files/cmake.mk \
+#	  $(QT_HOST_DATA)/mk/cmake.mk
+#endef
+
+define Build/InstallDev
+	$(call Build/InstallDev/Qt,$(1))
+
+	# target specific host tool `qmake`
+	$(INSTALL_DIR) \
+	  $(1)/host/etc/qt6 \
+	  $(1)/host/$(subst $(QT_HOST_PREFIX),,$(QT_HOST_BINS)) \
+	  $(1)/host/$(subst $(QT_HOST_PREFIX),,$(QT_HOST_LIBS)) \
+	  $(1)/host/$(subst $(QT_HOST_PREFIX),,$(QT_HOST_LIBEXECS)) \
+	  $(1)/host/$(subst $(QT_HOST_PREFIX),,$(QT_HOST_DATA)) \
+
+	# while there were 2 qmakes in qt5, one for the host, one for the target,
+	# it's the same binary but with different configs for qt6.
+	# the config is generated at build time and contains relative paths to its own location
+	# which assumptions are poor and don't allow for moving around.
+	# so we generate the qmake6 wrapper for the target and modify the config ourselves.
+	# (Sub)paths are computed based on Prefix and HostPrefix and derived from config/cmake
+	# INSTALL_*DIR-args.
+	# HostData is sth. special (at least everywhere in code it says so),
+	# and for reasons beyond my understanding, it's used as a search path for mkspecs,
+	# even for target builds.
+	ln -sf $(QT_HOSTPKG_MKSPECS) $(QT_HOST_DATA)/
+	sed \
+	  -e 's#\(^Prefix=\).*#\1$(STAGING_DIR)/$(QT_INSTALL_PREFIX)#' \
+	  -e 's#\(^HostPrefix=\).*#\1$(QT_HOST_PREFIX)#' \
+	  -e 's#\(^HostBinaries=\).*#\1$(subst $(QT_HOST_PREFIX)/,,$(QT_HOST_BINS))#' \
+	  -e 's#\(^HostLibrary=\).*#\1$(subst $(QT_HOST_PREFIX)/,,$(QT_HOST_LIBS))#' \
+	  -e 's#\(^HostLibraryExecutables=\).*#\1$(subst $(QT_HOST_PREFIX)/,,$(QT_HOST_LIBEXECS))#' \
+	  -e 's#\(^HostData=\).*#\1$(subst $(QT_HOST_PREFIX)/,,$(QT_HOST_DATA))#' \
+	  $(PKG_INSTALL_DIR)/$(QT_INSTALL_BINS)/target_qt.conf \
+	  > $(1)/host/etc/qt6/qmake-cross.conf
+
+	echo "$(QT_HOSTPKG_BINS)/qmake6 -qtconf '$(STAGING_DIR)/host/etc/qt6/qmake-cross.conf' \$$$$*" > $(1)/host/bin/qt6/qmake
+	chmod +x $(1)/host/bin/qt6/qmake
+endef
+
+define Package/qt6base-concurrent/install
+	$(call Build/Install/Libs,$(1),libQt6Concurrent)
+endef
+
+define Package/qt6base-core/install
+	$(call Build/Install/Libs,$(1),libQt6Core)
+endef
+
+define Package/qt6base-gui/install
+	$(call Build/Install/Libs,$(1),libQt6Gui)
+endef
+
+define Package/qt6base-network/install
+	$(call Build/Install/Libs,$(1),libQt6Network)
+	$(if $(CONFIG_BUILD_qt6base-network_SSL),$(call Build/Install/Plugins,$(1),tls,*),)
+endef
+
+define Package/qt6base-printSupport/install
+	$(call Build/Install/Libs,$(1),libQt6PrintSupport)
+endef
+
+define Package/qt6base-sql/install
+	$(call Build/Install/Libs,$(1),libQt6Sql)
+endef
+
+define Package/qt6base-test/install
+	$(call Build/Install/Libs,$(1),libQt6Test)
+endef
+
+define Package/qt6base-widgets/install
+	$(call Build/Install/Libs,$(1),libQt6Widgets)
+endef
+
+define Package/qt6base-openglwidgets/install
+	$(call Build/Install/Libs,$(1),libQt6OpenGLWidgets)
+endef
+
+define Package/qt6base-xml/install
+	$(call Build/Install/Libs,$(1),libQt6Xml)
+endef
+
+define Package/qt6base-opengl/install
+	$(call Build/Install/Libs,$(1),libQt6OpenGL)
+	$(call Build/Install/Libs,$(1),libQt6EglFsKmsSupport)
+	$(call Build/Install/Libs,$(1),libQt6EglFsKmsGbmSupport)
+	$(call Build/Install/Libs,$(1),libQt6EglFSDeviceIntegration)
+	$(call Build/Install/Plugins,$(1),egldeviceintegrations,libqeglfs-kms-egldevice-integration)
+	$(call Build/Install/Plugins,$(1),egldeviceintegrations,libqeglfs-kms-integration)
+	$(call Build/Install/Plugins,$(1),platforms,libqeglfs)
+endef
+
+define Package/qt6base-plugin-bearer-generic/install
+	$(call Build/Install/Plugins,$(1),bearer,libqgenericbearer)
+endef
+
+define Package/qt6base-plugin-input-libinput/install
+	$(call Build/Install/Plugins,$(1),generic,libqlibinputplugin)
+endef
+
+define Package/qt6base-plugin-input-evdevkeyboard/install
+	$(call Build/Install/Plugins,$(1),generic,libqevdevkeyboardplugin)
+endef
+
+define Package/qt6base-plugin-input-evdevmouse/install
+	$(call Build/Install/Plugins,$(1),generic,libqevdevmouseplugin)
+endef
+
+define Package/qt6base-plugin-input-evdevtablet/install
+	$(call Build/Install/Plugins,$(1),generic,libqevdevtabletplugin)
+endef
+
+define Package/qt6base-plugin-input-evdevtouch/install
+	$(call Build/Install/Plugins,$(1),generic,libqevdevtouchplugin)
+endef
+
+#define Package/qt6base-plugin-imageformats-gif/install
+#	$(call Build/Install/Plugins,$(1),imageformats,libqgif)
+#endef
+
+define Package/qt6base-plugin-imageformats-ico/install
+	$(call Build/Install/Plugins,$(1),imageformats,libqico)
+endef
+
+define Package/qt6base-plugin-imageformats-jpeg/install
+	$(call Build/Install/Plugins,$(1),imageformats,libqjpeg)
+endef
+
+define Package/qt6base-plugin-imageformats-png/install
+	true
+	#$(call Build/Install/Plugins,$(1),imageformats,libqpng)
+endef
+
+define Package/qt6base-plugin-platforms-minimal/install
+	$(call Build/Install/Plugins,$(1),platforms,libqminimal)
+endef
+
+define Package/qt6base-plugin-platforms-linuxfb/install
+	$(call Build/Install/Plugins,$(1),platforms,libqlinuxfb)
+endef
+
+define Package/qt6base-plugin-platforms-offscreen/install
+	$(call Build/Install/Plugins,$(1),platforms,libqoffscreen)
+endef
+
+define Package/qt6base-plugin-platforms-vnc/install
+	$(call Build/Install/Plugins,$(1),platforms,libqvnc)
+endef
+
+define Package/qt6base-plugin-platforms-minimalegl/install
+	$(call Build/Install/Plugins,$(1),platforms,libqminimalegl)
+endef
+
+define Package/qt6base-plugin-platforms-eglfs/install
+	true
+endef
+
+define Package/qt6base-examples/install
+	$(call Build/Install/Examples,$(1))
+endef
+
+# $(eval $(call BuildPackage,qt6base))
+$(eval $(call BuildPackage,qt6base-concurrent))
+$(eval $(call BuildPackage,qt6base-core))
+$(eval $(call BuildPackage,qt6base-gui))
+$(eval $(call BuildPackage,qt6base-opengl))
+$(eval $(call BuildPackage,qt6base-network))
+#$(eval $(call BuildPackage,qt6base-printSupport))
+#$(eval $(call BuildPackage,qt6base-sql))
+$(eval $(call BuildPackage,qt6base-test))
+$(eval $(call BuildPackage,qt6base-widgets))
+#$(eval $(call BuildPackage,qt6base-openglwidgets))
+$(eval $(call BuildPackage,qt6base-xml))
+#$(eval $(call BuildPackage,qt6base-plugin-bearer-generic))
+#$(eval $(call BuildPackage,qt6base-plugin-input-libinput))
+$(eval $(call BuildPackage,qt6base-plugin-input-evdevkeyboard))
+$(eval $(call BuildPackage,qt6base-plugin-input-evdevmouse))
+$(eval $(call BuildPackage,qt6base-plugin-input-evdevtablet))
+$(eval $(call BuildPackage,qt6base-plugin-input-evdevtouch))
+##$(eval $(call BuildPackage,qt6base-plugin-imageformats-gif))
+#$(eval $(call BuildPackage,qt6base-plugin-imageformats-ico))
+$(eval $(call BuildPackage,qt6base-plugin-imageformats-jpeg))
+$(eval $(call BuildPackage,qt6base-plugin-imageformats-png))
+$(eval $(call BuildPackage,qt6base-plugin-platforms-minimal))
+$(eval $(call BuildPackage,qt6base-plugin-platforms-linuxfb))
+$(eval $(call BuildPackage,qt6base-plugin-platforms-offscreen))
+$(eval $(call BuildPackage,qt6base-plugin-platforms-vnc))
+#$(eval $(call BuildPackage,qt6base-plugin-platforms-minimalegl))
+$(eval $(call BuildPackage,qt6base-plugin-platforms-eglfs))
+#$(eval $(call BuildPackage,qt6base-examples))
+$(eval $(call HostBuild))

--- a/frameworks/qt6/qt6base/files/mkspecs/linux-openwrt-g++/qmake.conf
+++ b/frameworks/qt6/qt6base/files/mkspecs/linux-openwrt-g++/qmake.conf
@@ -1,0 +1,42 @@
+#
+# qmake configuration for building with linux-openwrt-g++
+#
+
+MAKEFILE_GENERATOR      = UNIX
+CONFIG                 += incremental
+QMAKE_INCREMENTAL_STYLE = sublib
+
+include(../common/linux.conf)
+include(../common/gcc-base-unix.conf)
+include(../common/g++-unix.conf)
+
+QMAKE_CFLAGS_OPTIMIZE      =
+QMAKE_CFLAGS_OPTIMIZE_FULL =
+# for whatever reasons $QMAKE_C*FLAGS_RELEASE has set optimization flags directly, instead of referencing $QMAKE_CFLAGS_OPTIMIZE*, so clearing them explicitly, too
+QMAKE_CFLAGS_RELEASE   =
+QMAKE_CXXFLAGS_RELEASE = $$QMAKE_CFLAGS_RELEASE
+
+# modifications to gcc-base.conf (included by gcc-base-unix.conf)
+QMAKE_CFLAGS           += $$(TARGET_CFLAGS)
+QMAKE_CXXFLAGS         += $$(TARGET_CXXFLAGS)
+QMAKE_LFLAGS           += $$(TARGET_LDFLAGS)
+
+# modifications to g++.conf
+QMAKE_CC                = $$(TARGET_CROSS)gcc
+QMAKE_CXX               = $$(TARGET_CROSS)g++
+
+QMAKE_LINK_C            = $$QMAKE_CC
+QMAKE_LINK_C_SHLIB      = $$QMAKE_CC
+QMAKE_LINK              = $$QMAKE_CXX
+QMAKE_LINK_SHLIB        = $$QMAKE_CXX
+
+
+# modifications to linux.conf
+QMAKE_AR                = $$(TARGET_CROSS)ar cqs
+QMAKE_RANLIB            = $$(TARGET_CROSS)ranlib # QMAKE_RANLIB is set to NULL in linux.conf. Why? Not needed anymore? Set it anyway, just in case...
+QMAKE_OBJCOPY           = $$(TARGET_CROSS)objcopy
+QMAKE_NM                = $$(TARGET_CROSS)nm # whole qt5 project doesn't use $QMAKE_NM - wonder why it's defined in linux.conf at all. However better set it to ours than keep it being set to the host's version, just in case...
+QMAKE_STRIP             = # not used, since -no-strip is passed. Let's OpenWrt do the stripping
+
+
+load(qt_config)

--- a/frameworks/qt6/qt6base/files/mkspecs/linux-openwrt-g++/qplatformdefs.h
+++ b/frameworks/qt6/qt6base/files/mkspecs/linux-openwrt-g++/qplatformdefs.h
@@ -1,0 +1,34 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the qmake spec of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL21$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia. For licensing terms and
+** conditions see http://qt.digia.com/licensing. For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file. Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights. These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "../linux-g++/qplatformdefs.h"

--- a/frameworks/qt6/qt6base/files/mkspecs/linux-openwrt-host-g++/qmake.conf
+++ b/frameworks/qt6/qt6base/files/mkspecs/linux-openwrt-host-g++/qmake.conf
@@ -1,0 +1,18 @@
+#
+# qmake configuration for building with linux-openwrt-g++
+#
+
+MAKEFILE_GENERATOR      = UNIX
+CONFIG                 += incremental
+QMAKE_INCREMENTAL_STYLE = sublib
+
+include(../common/linux.conf)
+include(../common/gcc-base-unix.conf)
+include(../common/g++-unix.conf)
+
+# modifications to gcc-base.conf (included by gcc-base-unix.conf)
+QMAKE_CFLAGS   += ###TARGET_CFLAGS###
+QMAKE_CXXFLAGS += ###TARGET_CXXFLAGS###
+QMAKE_LFLAGS   += ###TARGET_LDFLAGS###
+
+load(qt_config)

--- a/frameworks/qt6/qt6base/files/mkspecs/linux-openwrt-host-g++/qplatformdefs.h
+++ b/frameworks/qt6/qt6base/files/mkspecs/linux-openwrt-host-g++/qplatformdefs.h
@@ -1,0 +1,34 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the qmake spec of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL21$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia. For licensing terms and
+** conditions see http://qt.digia.com/licensing. For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file. Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights. These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "../linux-g++/qplatformdefs.h"


### PR DESCRIPTION
Qt6 is a largely complex beast and given the experience from previous ports of Qt4 and Qt5, it will require quite some more work to accommodate all needs and configurations.

Qt6 kind of ditched support for qmake in favour of cmake, at least when it comes to building Qt6 and its official modules itself.

The qmake eco-system is and still needs to be supported though, as 3rd party projects are still allowed to use qmake - for the time being at least. qmake support for external projects untested for the time being, though.