### PR TITLE
mesa: setting meson opt mesa-clc to 'auto' if LLVM support disabled

### DIFF
--- a/libs/mesa/Makefile
+++ b/libs/mesa/Makefile
@@ -582,7 +582,7 @@ MESON_ARGS += \
 	-Dgallium-opencl=$(if $(CONFIG_MESA_USE_LLVM),standalone,disabled) \
 	-Ddraw-use-llvm=$(if $(CONFIG_MESA_USE_LLVM),true,false) \
 	-Dintel-clc=system \
-	-Dmesa-clc=system \
+	-Dmesa-clc=$(if $(CONFIG_MESA_USE_LLVM),system,auto) \
 	-Dprecomp-compiler=system
 
 ifeq ($(BUILD_VARIANT),amd)


### PR DESCRIPTION
mesa-clc set to 'system' requires the system tool 'mesa-clc' which gets built as part of the mesa/host build.
The mesa/host build however depends on LLVM and others - hence we're trying to avoid pulling in that dependency tree where possible for certain target configurations.

meson option 'mesa-clc' allows for 3 options: enabled, system, auto.

While 'auto' sounds like it will only automagically go for either 'enabled' or 'system', it will also disable CLC support entirely, if only drivers are enabled which don't need it (resulting in `with_clc=false`) - which is exactly what we want.