### PR TITLE
libxkbcommon: never run Python-based tests

### DIFF
--- a/libs/libxkbcommon/patches/100-no-python.patch
+++ b/libs/libxkbcommon/patches/100-no-python.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -783,7 +783,7 @@ test(
+ pymod = import('python')
+ python = pymod.find_installation('python3', modules: ['jinja2'], required: false)
+ has_merge_modes_tests = python.found() and python.language_version().version_compare('>=3.11')
+-if has_merge_modes_tests
++if false
+     script = find_program('scripts/update-merge-modes-tests.py')
+     merge_modes_tests = [meson.project_name()]
+     # NOTE: The following tests deal with third-party XKB compilers and are


### PR DESCRIPTION
Unfortunately there is no way to disable running the Python/Jinja2-based tests, so patch mesion.build in order to not fail in case of Python dependency problems on the host.