### PR TITLE
libxkbcommon: fix broken symlink

### DIFF
--- a/libs/libxkbcommon/Makefile
+++ b/libs/libxkbcommon/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxkbcommon
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=xkbcommon-$(PKG_VERSION)

--- a/libs/xkeyboard-config/Makefile
+++ b/libs/xkeyboard-config/Makefile
@@ -46,7 +46,7 @@ define Package/xkeyboard-config/install
 	$(INSTALL_DIR) $(1)/usr/share/xkeyboard-config-2
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/xkeyboard-config-2/* $(1)/usr/share/xkeyboard-config-2
 	$(INSTALL_DIR) $(1)/usr/share/X11
-	$(LN) ../../xkeyboard-config-2 $(1)/usr/share/X11/xkb
+	$(LN) ../xkeyboard-config-2 $(1)/usr/share/X11/xkb
 endef
 
 $(eval $(call BuildPackage,xkeyboard-config))


### PR DESCRIPTION
/usr/share/X11/xkb should point to ../xkeyboard-config-2 Remove the stray extra '../' to fix the symlink.

Fixes: 7873464 ("libxkbcommon: update to 1.10.0")