### PR TITLE
qt5base: only show OPENGL choice if qt5base-gui is selected

### DIFF
--- a/frameworks/qt5/qt5base/Config.in
+++ b/frameworks/qt5/qt5base/Config.in
@@ -18,6 +18,7 @@ config BUILD_qt5base-gui_DRM
 choice
     prompt "Which OpenGL variant to use"
     default BUILD_qt5base-gui_OPENGL_NONE
+    depends on PACKAGE_qt5base-gui
 
 config BUILD_qt5base-gui_OPENGL_OPENGLES2
     bool "es2"


### PR DESCRIPTION
The choice for the config option 'BUILD_qt5base-gui_OPENGL_OPENGLES2' and 'BUILD_qt5base-gui_OPENGL_NONE' should only be visible if 'qt5base-gui' is selected. This also applies to the default value if 'qt5base-gui' is not selected.