### PR TITLE
CI: switch to common formalities workflow

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -3,61 +3,16 @@ name: Test Formalities
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
-  build:
+  formalities:
     name: Test Formalities
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Determine branch name
-        run: |
-          BRANCH="${GITHUB_BASE_REF#refs/heads/}"
-          echo "Building for $BRANCH"
-          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
-
-      - name: Test formalities
-        run: |
-          source .github/workflows/ci_helpers.sh
-
-          RET=0
-          for commit in $(git rev-list HEAD ^origin/$BRANCH); do
-            info "=== Checking commit '$commit'"
-            if git show --format='%P' -s $commit | grep -qF ' '; then
-              err "Pull request should not include merge commits"
-              RET=1
-            fi
-
-            author="$(git show -s --format=%aN $commit)"
-            if echo $author | grep -q '\S\+\s\+\S\+'; then
-              success "Author name ($author) seems ok"
-            else
-              err "Author name ($author) need to be your real name 'firstname lastname'"
-              RET=1
-            fi
-
-            subject="$(git show -s --format=%s $commit)"
-            if echo "$subject" | grep -q -e '^[0-9A-Za-z,+/_-]\+: ' -e '^Revert '; then
-              success "Commit subject line seems ok ($subject)"
-            else
-              err "Commit subject line MUST start with '<package name>: ' ($subject)"
-              RET=1
-            fi
-
-            body="$(git show -s --format=%b $commit)"
-            sob="$(git show -s --format='Signed-off-by: %aN <%aE>' $commit)"
-            if echo "$body" | grep -qF "$sob"; then
-              success "Signed-off-by match author"
-            else
-              err "Signed-off-by is missing or doesn't match author (should be '$sob')"
-              RET=1
-            fi
-          done
-
-          exit $RET
+    uses: openwrt/actions-shared-workflows/.github/workflows/formal.yml@main
+    # with:
+    #   # Post formality check summaries to the PR.
+    #   # Repo's permissions need to be updated for actions to modify PRs:
+    #   # https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment
+    #   post_comment: true


### PR DESCRIPTION
Switch to using the common formalities workflow defined in the actions-shared-workflows.

CC: @Ansuel, @aparcar

TODO:
- [x] https://github.com/openwrt/actions-shared-workflows/pull/61