### PR TITLE
qt5: update source url to use qt archive

### DIFF
--- a/frameworks/qt5/common.mk
+++ b/frameworks/qt5/common.mk
@@ -54,7 +54,7 @@ ifeq (qt, $(firstword $(subst 5, ,$(PKG_NAME))))
 
 PKG_VERSION?=5.15.16
 
-PKG_SOURCE_URL?=https://download.qt.io/official_releases/qt/$(basename $(PKG_VERSION))/$(PKG_VERSION)/submodules
+PKG_SOURCE_URL?=https://download.qt.io/archive/qt/$(basename $(PKG_VERSION))/$(PKG_VERSION)/submodules
 PKG_SYS_NAME?=$(subst -,,$(subst $(firstword $(subst ., ,$(PKG_VERSION))),,$(PKG_NAME)))
 PKG_SYS_NAME_FULL?=$(PKG_SYS_NAME)-everywhere-src-$(PKG_VERSION)
 PKG_SOURCE?=$(subst -src-,-opensource-src-,$(PKG_SYS_NAME_FULL)).tar.xz


### PR DESCRIPTION
The official_releases directory returns 404 for Qt 5.15.16. Switching to the archive path ensures a reliable primary download.

Fixes #101
Relates to #72