### PR TITLE
assimp: update to 6.0.5 and disable LTO

### DIFF
--- a/libs/assimp/Makefile
+++ b/libs/assimp/Makefile
@@ -1,18 +1,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=assimp
-PKG_VERSION:=6.0.2
+PKG_VERSION:=6.0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/$(PKG_NAME)/$(PKG_NAME)/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d1822d9a19c9205d6e8bc533bf897174ddb360ce504680f294170cc1d6319751
+PKG_HASH:=edf3749559c2b7d1f758ffb66fc5bec62186221e623b7f2e8969f17ee46ecb6f
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 
 CMAKE_INSTALL:=1
-PKG_BUILD_FLAGS:=gc-sections lto
+PKG_BUILD_FLAGS:=gc-sections no-lto
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
**Maintainer:** @dangowrt
assimp: update to 6.0.5 and disable LTO

Bug fix release with various build/CI improvements and minor
fixes since 6.0.2.

LTO triggers internal compiler errors when building libassimp
against gcc-14 (with the OpenWrt fortify headers in the LTO
unit). Switch PKG_BUILD_FLAGS to 'gc-sections no-lto' to
unblock the build.

Link: https://github.com/assimp/assimp/releases/tag/v6.0.5
Signed-off-by: Daniel Golle <daniel@makrotopia.org>

