### PR TITLE
glm: update to 1.0.3

### DIFF
--- a/libs/glm/Makefile
+++ b/libs/glm/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glm
-PKG_VERSION:=1.0.1
+PKG_VERSION:=1.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/g-truc/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=9f3174561fd26904b23f0db5e560971cbf9b3cbda0b280f04d5c379d03bf234c
+PKG_HASH:=6775e47231a446fd086d660ecc18bcd076531cfedd912fbd66e576b118607001
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
**Maintainer:** @dangowrt

glm: update to 1.0.3

Patch release. The 1.0.x series is ABI-stable; 1.0.3 brings
mostly small fixes and CI/build-system updates over 1.0.1.

Link: https://github.com/g-truc/glm/releases/tag/1.0.3
Signed-off-by: Daniel Golle <daniel@makrotopia.org>

