### PR TITLE
libdisplay-info: update to 0.3.0

### DIFF
--- a/libs/libdisplay-info/Makefile
+++ b/libs/libdisplay-info/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdisplay-info
-PKG_VERSION:=0.2.0
+PKG_VERSION:=0.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/$(PKG_VERSION)
-PKG_HASH:=f7331fcaf5527251b84c8fb84238d06cd2f458422ce950c80e86c72927aa8c2b
+PKG_HASH:=2b467e3336aec63819d6aca28d7310d3dc7415b2b3a3c3a5aec9d3727053c078
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
**Maintainer:** @dangowrt

libdisplay-info: update to 0.3.0

Update from 0.2.0.

Link: https://gitlab.freedesktop.org/emersion/libdisplay-info/-/tags/0.3.0
Signed-off-by: Daniel Golle <daniel@makrotopia.org>

