### PR TITLE
libva: update to 2.23.0

### DIFF
--- a/libs/libva/Makefile
+++ b/libs/libva/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libva
-PKG_VERSION:=2.22.0
+PKG_VERSION:=2.23.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/intel/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=467c418c2640a178c6baad5be2e00d569842123763b80507721ab87eb7af8735
+PKG_HASH:=b10aceb30e93ddf13b2030eb70079574ba437be9b3b76065caf28a72c07e23e7
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
**Maintainer:** @dangowrt

libva: update to 2.23.0

Update from 2.22.0.

Link: https://github.com/intel/libva/releases/tag/2.23.0
Signed-off-by: Daniel Golle <daniel@makrotopia.org>

