### PR TITLE
sdl2: update to 2.32.10

### DIFF
--- a/libs/sdl2/Makefile
+++ b/libs/sdl2/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sdl2
-PKG_VERSION:=2.32.8
+PKG_VERSION:=2.32.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=SDL2-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.libsdl.org/release/
-PKG_HASH:=0ca83e9c9b31e18288c7ec811108e58bac1f1bb5ec6577ad386830eac51c787e
+PKG_HASH:=5f5993c530f084535c65a6879e9b26ad441169b3e25d789d83287040a9ca5165
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/SDL2-$(PKG_VERSION)
 
@@ -149,6 +149,8 @@ endef
 define Package/libsdl2-tests/install
 	$(INSTALL_DIR) $(1)/usr/libexec/installed-tests
 	$(CP) $(PKG_INSTALL_DIR)/usr/libexec/installed-tests/* $(1)/usr/libexec/installed-tests
+	$(INSTALL_DIR) $(1)/usr/share/installed-tests
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/installed-tests/* $(1)/usr/share/installed-tests
 endef
 
 $(eval $(call BuildPackage,libsdl2))

--- a/libs/sdl2/patches/110-tests-no-libunwind.patch
+++ b/libs/sdl2/patches/110-tests-no-libunwind.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1632,7 +1632,6 @@ elseif(UNIX AND NOT APPLE AND NOT RISCOS
+@@ -1642,7 +1642,6 @@ elseif(UNIX AND NOT APPLE AND NOT RISCOS
        endif()
  
      endif()

--- a/libs/sdl2/patches/120-tests-install-resources-to-datadir.patch
+++ b/libs/sdl2/patches/120-tests-install-resources-to-datadir.patch
@@ -1,0 +1,24 @@
+From: Daniel Golle <daniel@makrotopia.org>
+Subject: tests: install resource files to datadir, not libexecdir
+
+The .bmp / .hex / .txt / .dat / .wav files shipped alongside the test
+binaries are not executables; they are read-only data. Installing them
+under ${libexecdir}/installed-tests/SDL2/ is both inconsistent with the
+GNOME installed-tests convention (data lives under ${datadir}, only
+binaries under ${libexecdir}) and trips OpenWrt's package QA which
+expects every regular file in /usr/libexec/ to carry the executable
+bit. Move them to ${datadir}/installed-tests/SDL2/ alongside the
+matching ${exe}.test descriptors, and pin the permissions to 0644 so
+the umask of the build host cannot influence the installed mode.
+
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -531,6 +531,7 @@ if(SDL_INSTALL_TESTS)
+     endif()
+     install(
+         FILES ${RESOURCE_FILES}
+-        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/installed-tests/SDL2
++        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
++        DESTINATION ${CMAKE_INSTALL_DATADIR}/installed-tests/SDL2
+     )
+ endif()


### PR DESCRIPTION
**Maintainer:** @dangowrt

This is a stable bugfix release, with the following changes:

 * Fixed the dock occasionally showing on macOS when launching an SDL app

 * Report the correct device audio format when using Pipewire

 * Fixed signed 8-bit audio on Android

 * Support the "ambient" value for SDL_HINT_AUDIO_CATEGORY on iOS

 * Improved thumbstick range for Nintendo Switch Pro Controllers

 * Fixed loading user calibration for Nintendo Switch Pro Controllers

Patch 110-tests-no-libunwind.patch refreshed for the new upstream
context.

Add patch 120-tests-install-resources-to-datadir.patch which moves
the test resource files (.bmp, .hex, .txt, .dat, .wav) from
${libexecdir}/installed-tests/SDL2/ to
${datadir}/installed-tests/SDL2/, alongside the matching
${exe}.test descriptors. Upstream's install rule put them in
libexecdir, which is both inconsistent with the GNOME
installed-tests convention (data lives under datadir, only
binaries under libexecdir) and trips OpenWrt's package QA which
expects every regular file under /usr/libexec/ to carry the
executable bit. The patch also pins the install permissions to
0644 so the umask of the build host cannot influence the mode
of the installed files.