### PR TITLE
Vulkan SDK: update component group to 1.4.341.0 (glslang 16.2.0)

### DIFF
--- a/libs/glslang/Makefile
+++ b/libs/glslang/Makefile
@@ -1,19 +1,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glslang
-PKG_VERSION:=15.4.0
+# 16.2.0 references the same commit as the Vulkan SDK 1.4.341.0 release tag
+# (vulkan-sdk-1.4.341.0); use the semver tag here to keep package-manager
+# version comparisons monotonic.
+PKG_VERSION:=16.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=b16c78e7604b9be9f546ee35ad8b6db6f39bbbbfb19e8d038b6fe2ea5bba4ff4
+PKG_HASH:=01985335785c97906a91afe3cb5ee015997696181ec6c125bab5555602ba08e2
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause BSD-2-Clause MIT Apache GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE.txt
 
 CMAKE_INSTALL:=1
-PKG_BUILD_FLAGS:=gc-sections lto
+PKG_BUILD_FLAGS:=gc-sections no-lto
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk

--- a/libs/spirv-headers/Makefile
+++ b/libs/spirv-headers/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spirv-headers
-PKG_VERSION:=1.4.328.0
+PKG_VERSION:=1.4.341.0
 
 PKG_SOURCE:=SPIRV-Headers-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/SPIRV-Headers/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=00284a33e1e19014723c8e88ca7a16e8988cd23f839ec2b7da6bb1808fd2a751
+PKG_HASH:=cab0a654c4917e16367483296b44cdb1d614e3120c721beafcd37e3a8580486c
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT

--- a/libs/spirv-tools/Makefile
+++ b/libs/spirv-tools/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spirv-tools
-PKG_VERSION:=1.4.328.0
+PKG_VERSION:=1.4.341.0
 
 PKG_SOURCE:=SPIRV-Tools-vulkan-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/SPIRV-Tools/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=bdd1692ad5cba1bdf8ace0850bcacc32abc2abfaef373328689fa2809ab7027f
+PKG_HASH:=15bfb678138cdf9cd1480dfb952547bbb66b763a735b6d5582578572f5c2e6f9
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT
@@ -26,11 +26,13 @@ include $(INCLUDE_DIR)/cmake.mk
 
 CMAKE_OPTIONS += \
 	-DSPIRV-Headers_SOURCE_DIR=$(STAGING_DIR)/usr \
-	-DSPIRV_SKIP_TESTS=ON
+	-DSPIRV_SKIP_TESTS=ON \
+	-DSPIRV_WERROR=OFF
 
 CMAKE_HOST_OPTIONS += \
 	-DSPIRV-Headers_SOURCE_DIR=$(STAGING_DIR_HOSTPKG) \
-	-DSPIRV_SKIP_TESTS=ON
+	-DSPIRV_SKIP_TESTS=ON \
+	-DSPIRV_WERROR=OFF
 
 define Package/spirv-tools
   SECTION:=devel

--- a/libs/vulkan-headers/Makefile
+++ b/libs/vulkan-headers/Makefile
@@ -1,16 +1,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vulkan-headers
-PKG_VERSION:=1.4.328
-PKG_SOURCE:=Vulkan-Headers-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/Vulkan-Headers/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3ad56d387179b47dd632432ccf989bbb69773e1d732692b7bbad9c4d36aa1304
+PKG_VERSION:=1.4.341.0
+PKG_SOURCE:=Vulkan-Headers-vulkan-sdk-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/Vulkan-Headers/tar.gz/vulkan-sdk-$(PKG_VERSION)?
+PKG_HASH:=d73bc5036b6556b741f6985ff600ca720308c5f2850e4a43ceb498bd3de069e7
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=Apache-2.0 OR MIT
 PKG_LICENSE_FILES:=LICENSE.md
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/Vulkan-Headers-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/Vulkan-Headers-vulkan-sdk-$(PKG_VERSION)
 
 CMAKE_BINARY_SUBDIR:=build
 CMAKE_INSTALL:=1

--- a/libs/vulkan-loader/Makefile
+++ b/libs/vulkan-loader/Makefile
@@ -1,17 +1,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vulkan-loader
-PKG_VERSION:=1.4.328
+PKG_VERSION:=1.4.341.0
 
-PKG_SOURCE:=Vulkan-Loader-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/Vulkan-Loader/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=07b5bae70dabdd2ee5a0fdaea95f72dac9561ddd768b0739d4af6cb8771e9ac8
+PKG_SOURCE:=Vulkan-Loader-vulkan-sdk-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/Vulkan-Loader/tar.gz/vulkan-sdk-$(PKG_VERSION)?
+PKG_HASH:=fe982697c780a950641bfcf94707135c26c501352242d285fa95d087d691292e
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/Vulkan-Loader-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/Vulkan-Loader-vulkan-sdk-$(PKG_VERSION)
 
 PKG_BUILD_DEPENDS:=vulkan-headers
 CMAKE_BINARY_SUBDIR:=build


### PR DESCRIPTION
**Maintainer:** @dangowrt

Update the entire Vulkan SDK component group to the current
official LunarG Vulkan SDK 1.4.341 release, in dependency order:

1. **vulkan-headers**: 1.4.328 -> `vulkan-sdk-1.4.341.0`
2. **vulkan-loader**: 1.4.328 -> `vulkan-sdk-1.4.341.0` (depends on vulkan-headers)
3. **spirv-headers**: 1.4.328.0 -> `vulkan-sdk-1.4.341.0`
4. **spirv-tools**: 1.4.328.0 -> `vulkan-sdk-1.4.341.0` (depends on spirv-headers)
5. **glslang**: 15.4.0 -> **16.2.0** (depends on spirv-tools)

The version `1.4.341.0` is the component-side tag that is
referenced by all of LunarG's SDK manifest. The LunarG SDK
distribution version is `1.4.341.1`, but that is a packaging-only
revision and there is no `vulkan-sdk-1.4.341.1` tag on any
component, so the four SDK-versioned Makefiles use
`PKG_VERSION:=1.4.341.0` with the `vulkan-sdk-$(PKG_VERSION)`
URL pattern.

`glslang` is special: upstream ships **two equivalent tags** for
each SDK release - a semver tag (`16.2.0`) and a SDK tag
(`vulkan-sdk-1.4.341.0`). Both resolve to the same commit
(`f0bd0257c308b9a26562c1a30c4748a0219cc951`). We use the semver
tag in the Makefile so package-manager version comparisons stay
monotonic relative to the previous `15.4.0` packaging - pinning
to `1.4.341.0` would otherwise look like a downgrade to dpkg /
opkg / apk. The equivalence is documented in a comment in the
Makefile and in the commit message.

Build adjustments:

* `spirv-tools`: add `-DSPIRV_WERROR=OFF` to host and target
  cmake options to keep the build going through gcc-14
  `-Wmaybe-uninitialized` warnings that would otherwise trip
  `-Werror`.
* `glslang`: disable LTO via `PKG_BUILD_FLAGS:=gc-sections
  no-lto`. Without that, upstream hits an `inlining failed in
  call to always_inline 'vsnprintf': function body can be
  overwritten at link time` error during LTO with the OpenWrt
  fortify headers in 16.x.

Upstream:
* https://vulkan.lunarg.com/sdk/home
* https://github.com/KhronosGroup/Vulkan-Headers/releases/tag/vulkan-sdk-1.4.341.0
* https://github.com/KhronosGroup/Vulkan-Loader/releases/tag/vulkan-sdk-1.4.341.0
* https://github.com/KhronosGroup/SPIRV-Headers/releases/tag/vulkan-sdk-1.4.341.0
* https://github.com/KhronosGroup/SPIRV-Tools/releases/tag/vulkan-sdk-1.4.341.0
* https://github.com/KhronosGroup/glslang/releases/tag/16.2.0 (= vulkan-sdk-1.4.341.0)
