### PR TITLE
wayland, wayland-protocols, wayland-utils: update to 1.25.0 / 1.48 / 1.3.0

### DIFF
--- a/frameworks/wayland-protocols/Makefile
+++ b/frameworks/wayland-protocols/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wayland-protocols
-PKG_VERSION:=1.45
+PKG_VERSION:=1.48
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/$(PKG_VERSION)/downloads/
-PKG_HASH:=4d2b2a9e3e099d017dc8107bf1c334d27bb87d9e4aff19a0c8d856d17cd41ef0
+PKG_HASH:=398036ac0eb6484982ddbde7ff86848d753231f9cdeeae983f06b52946625aa1
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT
@@ -38,6 +38,8 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/share/wayland-protocols
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/wayland-protocols/* $(1)/usr/share/wayland-protocols
+	$(INSTALL_DIR) $(1)/usr/include/wayland-protocols
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/wayland-protocols/*.h $(1)/usr/include/wayland-protocols
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/pkgconfig/*.pc $(1)/usr/lib/pkgconfig
 endef

--- a/frameworks/wayland/Makefile
+++ b/frameworks/wayland/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wayland
-PKG_VERSION:=1.23.0
+PKG_VERSION:=1.25.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/wayland/wayland/-/releases/$(PKG_VERSION)/downloads/
-PKG_HASH:=05b3e1574d3e67626b5974f862f36b5b427c7ceeb965cb36a4e6c2d342e45ab2
+PKG_HASH:=c065f040afdff3177680600f249727e41a1afc22fccf27222f15f5306faa1f03
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT

--- a/frameworks/wayland/patches/001-fix-wayland-scanner-detect.patch
+++ b/frameworks/wayland/patches/001-fix-wayland-scanner-detect.patch
@@ -1,6 +1,6 @@
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -81,8 +81,12 @@ if get_option('scanner')
+@@ -80,8 +80,12 @@ if get_option('scanner')
  endif
  
  if meson.is_cross_build() or not get_option('scanner')

--- a/libs/wayland-utils/Makefile
+++ b/libs/wayland-utils/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wayland-utils
-PKG_VERSION:=1.2.0
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/wayland/wayland-utils/-/releases/$(PKG_VERSION)/downloads/
-PKG_HASH:=d9278c22554586881802540751bcc42569262bf80cd9ac9b0fd12ff4bd09a9e4
+PKG_HASH:=a39d0e65617c6ae186d768c223f57060a3a435f6f9f02d03074f945313bfcf0d
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
**Maintainer:** @dangowrt

Update the wayland trio in dependency order:

1. **wayland**: 1.23.0 -> 1.25.0 (low-level)
2. **wayland-protocols**: 1.45 -> 1.48 (depends on wayland)
3. **wayland-utils**: 1.2.0 -> 1.3.0 (depends on wayland + wayland-protocols)

`wayland-utils` only depends on the `wayland`, `wayland-protocols`
and `libdrm` packages from layer-0 / lower layers; the first two
are bundled in this PR, `libdrm` lives in the `packages` feed
(separate PR there is already open: openwrt/packages#29382).

### wayland 1.25.0
Bump from 1.23.0 to current upstream stable.

Link: https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.25.0

### wayland-protocols 1.48
Bump from 1.45 to current upstream stable.

1.48 introduces the new `enum-header` wayland-scanner mode that
generates a `*-enum.h` header per protocol. wlroots 0.20+ relies
on these. Extend `Build/InstallDev` to copy
`/usr/include/wayland-protocols/*.h` into staging so consumers
can include them via `<wayland-protocols/...-enum.h>`.

Link: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.48

### wayland-utils 1.3.0
Bump from 1.2.0.

Link: https://gitlab.freedesktop.org/wayland/wayland-utils/-/tags/1.3.0
