### PR TITLE
harfbuzz: update to 14.2.0

### DIFF
--- a/libs/harfbuzz/Makefile
+++ b/libs/harfbuzz/Makefile
@@ -1,18 +1,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=harfbuzz
-PKG_VERSION:=11.2.1
+PKG_VERSION:=14.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/harfbuzz/harfbuzz/releases/download/$(PKG_VERSION)/
-PKG_HASH:=093714c8548a285094685f0bdc999e202d666b59eeb3df2ff921ab68b8336a49
+PKG_HASH:=94017020f96d025bb66ae91574e4cf334bcad23e8175a8a40565b3721bc2eaff
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
+
+PKG_BUILD_DEPENDS:=glib2/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk


### PR DESCRIPTION
**Maintainer:** @dangowrt

Major release stream from 11.2.1 to 14.x. harfbuzz uses linear
versioning with each major bringing new shaping features and
improvements; 14.x is the current stable line.

Add PKG_BUILD_DEPENDS:=glib2/host: harfbuzz's meson.build pulls
glib_mkenums via the glib-2.0 pkg-config 'tool variable', and
OpenWrt's glib2 install rewrites gio-2.0.pc / glib-2.0.pc to point
at $(STAGING_DIR_HOSTPKG)/bin/glib-mkenums. That host binary is
only produced when glib2's host build runs, and without an
explicit dep on glib2/host the host build is skipped on clean CI
images that lack a system glib (failure message: "Program
/builder/staging_dir/hostpkg/bin/glib-mkenums found: NO -
Dependency 'glib-2.0' tool variable 'glib_mkenums' contains
erroneous value").

Link: https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0

