### PR TITLE
wlroots: update to 0.20.0

### DIFF
--- a/frameworks/wlroots/Makefile
+++ b/frameworks/wlroots/Makefile
@@ -2,11 +2,11 @@ include $(TOPDIR)/rules.mk
 
 
 PKG_NAME:=wlroots
-PKG_VERSION:=0.18.2
+PKG_VERSION:=0.20.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/$(PKG_NAME)/$(PKG_NAME)/-/archive/$(PKG_VERSION)
-PKG_HASH:=703c515917d9eb258e44296795f8626190e119b0ee8bfb32fe9f834dab1a1462
+PKG_HASH:=e2d024916ed3bd011e058e78007655469e8c624fc338a28da610b087793b887b
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
**Maintainer:** @dangowrt

Bump from 0.18.2 to current upstream stable.

Requires libdrm >= 2.4.129 and wayland-protocols 1.48+ with
the enum-header generator.

Link: https://gitlab.freedesktop.org/wlroots/wlroots/-/releases/0.20.0

