### PR TITLE
gdk-pixbuf: update to 2.44.6

### DIFF
--- a/libs/gdk-pixbuf/Makefile
+++ b/libs/gdk-pixbuf/Makefile
@@ -1,23 +1,26 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gdk-pixbuf
-PKG_VERSION:=2.42.12
+PKG_VERSION:=2.44.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/$(PKG_NAME)/$(basename $(PKG_VERSION))
-PKG_HASH:=b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7
+PKG_HASH:=140c2d0b899fcf853ee92b26373c9dc228dbcde0820a4246693f4328a27466fa
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:gnome:gdk-pixbuf
 
+PKG_BUILD_DEPENDS:=glib2/host
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk
 
 MESON_ARGS += \
-	-Dgtk_doc=false \
+	-Ddocumentation=false \
+	-Dglycin=disabled \
 	-Dinstalled_tests=false \
 	-Dman=false \
 	-Dtests=false
@@ -60,5 +63,4 @@ define Package/libgdk-pixbuf/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/lib/
 endef
 
-$(eval $(call HostBuild))
 $(eval $(call BuildPackage,libgdk-pixbuf))

--- a/libs/gdk-pixbuf/patches/100-no-gi-docgen.patch
+++ b/libs/gdk-pixbuf/patches/100-no-gi-docgen.patch
@@ -1,10 +1,11 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -399,7 +399,7 @@ endif
+@@ -447,7 +447,8 @@ else
+ endif
  
  # Documentation
- build_docs = get_option('gtk_doc') or get_option('docs')
 -subdir('docs')
++build_docs = false
 +# subdir('docs')
  
  if not meson.is_cross_build()


### PR DESCRIPTION
**Maintainer:** @dangowrt

This series introduces the GLib-based gen-resources.py support
(new in 2.44) and other minor improvements over 2.42.12.

Add PKG_BUILD_DEPENDS:=glib2/host: gdk-pixbuf's meson.build now
calls find_program('glib-compile-resources') to invoke the GLib
host-side resource compiler during configure. The binary is
provided by glib2's host build at $(STAGING_DIR_HOSTPKG)/bin/,
so the dep is needed to make that host build actually run on
clean CI images (failure message: "Program glib-compile-resources
found: NO - ERROR: Program 'glib-compile-resources' not found or
not executable").

Drop the leftover '$(eval $(call HostBuild))' line: gdk-pixbuf
never included host-build.mk so the call was a no-op anyway.

Link: https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/blob/2.44.6/NEWS

