### PR TITLE
graphene: update to GIT HEAD of 2025-12-19

### DIFF
--- a/libs/graphene/Makefile
+++ b/libs/graphene/Makefile
@@ -4,10 +4,10 @@ PKG_NAME:=graphene
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2025-01-23
-PKG_SOURCE_VERSION:=47b503d6086900057ceefab785546ad524caa735
+PKG_SOURCE_DATE:=2025-12-19
+PKG_SOURCE_VERSION:=98173e59a3d80d3dd5ad6e4eaab919b4649ac7e5
 PKG_SOURCE_URL:=https://github.com/ebassi/graphene
-PKG_MIRROR_HASH:=8c150016ca717c6a829c46c8617f7a5a9136a9b9a918b078d97ee0cb7ee6991c
+PKG_MIRROR_HASH:=841b66ddff456352f19e617ca0bedf70950834cbe230f3632038aa007e2dbb57
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT
@@ -52,7 +52,7 @@ endef
 
 define Package/libgraphene/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib
 endef
 
 $(eval $(call BuildPackage,libgraphene))


### PR DESCRIPTION
**Maintainer:** @dangowrt

Update PKG_SOURCE_VERSION to 98173e59a3d80d3dd5ad6e4eaab919b4649ac7e5
to pick up build-system fixes accumulated since the previous
2025-01-23 snapshot.

graphene has no tagged releases since 1.10.8 (2022); track upstream
master.

Switch Package/libgraphene/install from $(INSTALL_BIN) to $(CP):
INSTALL_BIN does not preserve symlinks, so the installed image was
ending up with three identical 148648-byte copies of the library
(libgraphene-1.0.so, libgraphene-1.0.so.0, libgraphene-1.0.so.0.1101.0)
instead of the upstream-installed symlink chain. The shlibs check
flagged this as "Library has SONAME 'libgraphene-1.0.so.0' but no
corresponding symlink was found in /usr/lib". $(CP), which expands
to "cp -fpR", preserves the symlinks correctly.

Link: https://gitlab.gnome.org/GNOME/graphene/-/commits/master

