### PR TITLE
mesa: drop symmetric CONFLICTS between libteflon-rocket and libteflon-etnaviv

### DIFF
--- a/libs/mesa/Makefile
+++ b/libs/mesa/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mesa
 PKG_VERSION:=26.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://archive.mesa3d.org/
@@ -475,7 +475,6 @@ $(call Package/mesa/Default)
   TITLE+= TFLite delegate for VeriSilicon NPU (etnaviv)
   DEPENDS+=+libdrm-etnaviv +libexpat +libzstd +zlib @aarch64
   VARIANT:=teflon-etnaviv
-  CONFLICTS:=libteflon-rocket
 endef
 
 define Package/libteflon-etnaviv/description


### PR DESCRIPTION
**Maintainer:** @dangowrt

The libteflon-rocket and libteflon-etnaviv packages both install
/usr/lib/libteflon.so so they truly do conflict at install time -
and OpenWrt's apk has no built-in mechanism for refusing to
overwrite an already-installed file, so the CONFLICTS declaration
is necessary to keep both from being installed simultaneously.

However, OpenWrt's BuildPackage translates CONFLICTS into a
Kconfig 'depends on !PACKAGE_<other>' clause, and a mutual
declaration (both packages list each other) creates a recursive
dependency:

  tmp/.config-package.in:57925:error: recursive dependency detected!
    symbol PACKAGE_libteflon-etnaviv depends on PACKAGE_libteflon-rocket
    symbol PACKAGE_libteflon-rocket depends on PACKAGE_libteflon-etnaviv

Make the CONFLICTS declaration asymmetric: only libteflon-rocket
declares CONFLICTS:=libteflon-etnaviv. That single side is
sufficient to force the mutual exclusion at Kconfig time
(selecting either disables the other) while breaking the cycle
that the symmetric form created.

Bump PKG_RELEASE to 2 since this is a Makefile-only fix on an
already-released PKG_VERSION (26.0.6).

