### PR TITLE
mesa: update to version 26.1.1

### DIFF
--- a/libs/mesa/Makefile
+++ b/libs/mesa/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mesa
-PKG_VERSION:=26.0.6
-PKG_RELEASE:=2
+PKG_VERSION:=26.1.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://archive.mesa3d.org/
-PKG_HASH:=1d3c3b8a8363b8cc354175bb4a684ad8b035211cc1d6fa17aeb9b9623c513f89
+PKG_HASH:=8bd36c031cc6d0edfec04617527609454ee3a09ad53bdf983b45fc2c1e129b2e
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause

--- a/libs/mesa/patches/100-meson-allow-using-LLVM-as-embedded-project.patch
+++ b/libs/mesa/patches/100-meson-allow-using-LLVM-as-embedded-project.patch
@@ -10,7 +10,7 @@ Subject: [PATCH 1/2] meson: allow using LLVM as embedded project
 
 --- a/meson.build
 +++ b/meson.build
-@@ -1841,17 +1841,29 @@ _shared_llvm = get_option('shared-llvm')
+@@ -1895,17 +1895,29 @@ _shared_llvm = get_option('shared-llvm')
    .disable_auto_if(host_machine.system() == 'windows') \
    .allowed()
  
@@ -51,7 +51,7 @@ Subject: [PATCH 1/2] meson: allow using LLVM as embedded project
  if dep_llvm.found()
    pre_args += '-DMESA_LLVM_VERSION_STRING="@0@"'.format(dep_llvm.version())
    pre_args += '-DLLVM_IS_SHARED=@0@'.format(_shared_llvm.to_int())
-@@ -1938,7 +1950,11 @@ endif
+@@ -1992,7 +2004,11 @@ endif
  
  dep_clang = null_dep
  if with_clc

--- a/libs/mesa/patches/200-panfrost-Enable-cross-compilation-of-precompilers-on.patch
+++ b/libs/mesa/patches/200-panfrost-Enable-cross-compilation-of-precompilers-on.patch
@@ -1,8 +1,6 @@
-From ed8b98238061e6260ffaf507597e114a5a80ca4f Mon Sep 17 00:00:00 2001
 From: Daniel Golle <daniel@makrotopia.org>
 Date: Mon, 13 Oct 2025 01:32:22 +0100
-Subject: [PATCH 2/2] panfrost: Enable cross-compilation of precompilers on
- non-Linux hosts
+Subject: panfrost: Enable cross-compilation of precompilers on non-Linux hosts
 
 This patch enables building Mesa's Panfrost precompilers on non-Linux
 hosts (macOS, Windows, etc.) by introducing a stub kernel mode driver
@@ -18,8 +16,8 @@ Changes:
 1. Created kmod/pan_kmod_stub.h with minimal type definitions needed
    by pan_desc.h inline functions (pan_kmod_dev_props)
 
-2. Modified pan_desc.h to conditionally include either the full kmod
-   header or the stub version based on PAN_KMOD_STUB define
+2. Modified pan_desc.h and pan_image.h to conditionally include either
+   the full kmod header or the stub version based on PAN_KMOD_STUB
 
 3. Updated build system to:
    - Skip building kmod/ subdirectory when not needed
@@ -31,23 +29,17 @@ Changes:
 4. Extended panfrost build to support with_drivers_clc for CLC
    precompiler requirements
 
-This allows building Panfrost precompilers for cross-compilation
-scenarios without requiring a Linux host or DRM development headers,
-while maintaining full backward compatibility for regular driver builds.
----
- src/meson.build                       |  2 +-
- src/panfrost/lib/kmod/pan_kmod_stub.h | 27 ++++++++++++++
- src/panfrost/lib/meson.build          | 51 ++++++++++++++++++++-------
- src/panfrost/lib/pan_desc.h           |  4 +++
- src/panfrost/meson.build              |  2 +-
- 5 files changed, 71 insertions(+), 15 deletions(-)
- create mode 100644 src/panfrost/lib/kmod/pan_kmod_stub.h
+Refreshed against Mesa 26.1.1: the per-arch source list now contains
+pan_buffer.c, pan_fb.c and pan_fb_nir.c in addition to pan_blend.c
+and pan_texture.c.  All of those include pan_desc.h transitively but
+do not call into kmod, so they can build against the stub header on
+non-Linux hosts.
 
 --- a/src/meson.build
 +++ b/src/meson.build
 @@ -92,7 +92,7 @@ endif
- if with_imagination_vk or with_tools.contains('imagination')
-   subdir('imagination')
+ if with_any_intel
+   subdir('intel')
  endif
 -if with_gallium_panfrost or with_gallium_lima or with_panfrost_vk or with_tools.contains('panfrost')
 +if with_drivers_clc or with_gallium_panfrost or with_gallium_lima or with_panfrost_vk or with_tools.contains('panfrost')
@@ -99,16 +91,21 @@ while maintaining full backward compatibility for regular driver builds.
  
  pixel_format_versions = ['5', '6', '7', '9', '10', '12', '13']
  libpanfrost_pixel_format = []
-@@ -21,18 +23,23 @@ foreach ver : pixel_format_versions
+@@ -21,21 +23,28 @@ foreach ver : pixel_format_versions
  endforeach
  
  libpanfrost_per_arch = []
-+libpanfrost_per_arch_files = [ 'pan_blend.c', 'pan_texture.c' ]
++libpanfrost_per_arch_files = [
++  'pan_blend.c',
++  'pan_buffer.c',
++  'pan_fb.c',
++  'pan_fb_nir.c',
++  'pan_texture.c',
++]
 +libpanfrost_per_arch_c_args = []
 +
 +if with_gallium_panfrost or with_panfrost_vk
-+  libpanfrost_per_arch_files += 'pan_desc.c'
-+  libpanfrost_per_arch_files += 'pan_mod.c'
++  libpanfrost_per_arch_files += ['pan_desc.c', 'pan_mod.c']
 +else
 +  # Building without full driver support (e.g., for precompilers only)
 +  # Use stub kmod definitions to avoid requiring DRM headers
@@ -120,7 +117,10 @@ while maintaining full backward compatibility for regular driver builds.
 -    'pan-arch-v' + ver,
 -    [
 -      'pan_blend.c',
+-      'pan_buffer.c',
 -      'pan_desc.c',
+-      'pan_fb.c',
+-      'pan_fb_nir.c',
 -      'pan_mod.c',
 -      'pan_texture.c',
 -    ],
@@ -131,10 +131,10 @@ while maintaining full backward compatibility for regular driver builds.
      gnu_symbol_visibility : 'hidden',
      dependencies : [deps_for_libpanfrost, idep_nir],
    )
-@@ -48,26 +55,44 @@ libpanfrost_lib_files = files(
-   'pan_tiler.c',
+@@ -52,26 +61,44 @@ libpanfrost_lib_files = files(
    'pan_layout.c',
    'pan_scratch.c',
+   'pan_trace.c',
 -  'pan_props.c',
    'pan_util.c',
    'pan_afbc.c',
@@ -169,7 +169,7 @@ while maintaining full backward compatibility for regular driver builds.
  
 +libpanfrost_dependencies = [deps_for_libpanfrost, idep_nir]
 +if with_gallium_panfrost or with_panfrost_vk
-+  libpanfrost_dependencies = libpankmod_dep
++  libpanfrost_dependencies += libpankmod_dep
 +endif
 +
  libpanfrost_dep = declare_dependency(

--- a/libs/mesa/patches/600-zink-allow-kms-only-display-fd.patch
+++ b/libs/mesa/patches/600-zink-allow-kms-only-display-fd.patch
@@ -1,0 +1,39 @@
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Mon, 25 May 2026 22:00:00 +0100
+Subject: zink: allow KMS-only display fd to fall through to default
+ Vulkan device selection
+
+When MESA_LOADER_DRIVER_OVERRIDE=zink is used with a GBM device created
+on a KMS-only display node (e.g. /dev/dri/card1 bound to verisilicon-dc
+on StarFive JH7110), zink_render_rdev() returned -1 because the device
+has no render node, causing zink_drm_create_screen() to bail and GBM
+initialisation to fail.
+
+Treat the missing render node as "no specific device requested" instead
+of an error.  zink_picks_device() then returns false, and choose_pdev()
+falls back to default Vulkan physical-device selection, picking
+whichever ICD vkEnumeratePhysicalDevices() reports first (PowerVR on
+JH7110).  Cross-device dma-buf import via VK_KHR_external_memory_fd
+takes care of getting the rendered frame onto the display controller.
+
+--- a/src/gallium/drivers/zink/zink_screen.c
++++ b/src/gallium/drivers/zink/zink_screen.c
+@@ -3862,10 +3862,15 @@ zink_render_rdev(int fd, int64_t *dev_ma
+    if (drmGetDevice2(fd, 0, &dev))
+       return -1;
+ 
+-   if(!(dev->available_nodes & (1 << DRM_NODE_RENDER))) {
+-      ret = -1;
++   /*
++    * If the fd points to a KMS-only display device with no render node,
++    * leave dev_major/dev_minor unset.  choose_pdev() will then fall back
++    * to default Vulkan physical-device selection, allowing zink to drive
++    * a render-only GPU (e.g. PowerVR via VK_KHR_external_memory_fd) on
++    * top of a separate display controller (e.g. verisilicon-dc).
++    */
++   if(!(dev->available_nodes & (1 << DRM_NODE_RENDER)))
+       goto free_device;
+-   }
+ 
+    if(stat(dev->nodes[DRM_NODE_RENDER], &stx)) {
+       ret = -1;


### PR DESCRIPTION
The first stable release of the Mesa 26.1 release branch comes with countless new features and bugfixes since 26.0.6.

Link: https://docs.mesa3d.org/relnotes/26.1.0.html
Link: https://docs.mesa3d.org/relnotes/26.1.1.html