### PR TITLE
vkmark: fix build if Vulkan is present on host

### DIFF
--- a/utils/vkmark/Makefile
+++ b/utils/vkmark/Makefile
@@ -32,6 +32,8 @@ define Package/vkmark/description
 vkmark is an extensible Vulkan benchmarking suite with targeted, configurable scenes.
 endef
 
+MESON_VARS += CMAKE_PREFIX_PATH=$(STAGING_DIR)/usr
+
 MESON_ARGS += \
 	-Dxcb=false \
 	-Dwayland=true \


### PR DESCRIPTION
Make sure to not pick up host headers and libraries by setting CMAKE_PREFIX_PATH.