### PR TITLE
vulkan: update stack to SDK 1.4.350

### DIFF
--- a/libs/glslang/Makefile
+++ b/libs/glslang/Makefile
@@ -1,15 +1,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glslang
-# 16.2.0 references the same commit as the Vulkan SDK 1.4.341.0 release tag
-# (vulkan-sdk-1.4.341.0); use the semver tag here to keep package-manager
+# 16.3.0 references the same commit as the Vulkan SDK 1.4.350.0 release tag
+# (vulkan-sdk-1.4.350.0); use the semver tag here to keep package-manager
 # version comparisons monotonic.
-PKG_VERSION:=16.2.0
+PKG_VERSION:=16.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=01985335785c97906a91afe3cb5ee015997696181ec6c125bab5555602ba08e2
+PKG_HASH:=efff5a15258dce1ca2d323bf64c974f5fca03778174615dbc30c8d36db645bf5
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause BSD-2-Clause MIT Apache GPL-3.0-or-later

--- a/libs/spirv-headers/Makefile
+++ b/libs/spirv-headers/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spirv-headers
-PKG_VERSION:=1.4.341.0
+PKG_VERSION:=1.4.350.0
 
 PKG_SOURCE:=SPIRV-Headers-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/SPIRV-Headers/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=cab0a654c4917e16367483296b44cdb1d614e3120c721beafcd37e3a8580486c
+PKG_HASH:=9905d9341f20388adb852c77dd982f2c4d539fd68e6c1f1bcebf034715f2d1d5
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT

--- a/libs/spirv-tools/Makefile
+++ b/libs/spirv-tools/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spirv-tools
-PKG_VERSION:=1.4.341.0
+PKG_VERSION:=1.4.350.0
 
 PKG_SOURCE:=SPIRV-Tools-vulkan-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/SPIRV-Tools/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=15bfb678138cdf9cd1480dfb952547bbb66b763a735b6d5582578572f5c2e6f9
+PKG_HASH:=446b288fe76d3f31bbf9a405d62b97020ac0f135edb0ed5dbdf1136c488138f5
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT

--- a/libs/vulkan-headers/Makefile
+++ b/libs/vulkan-headers/Makefile
@@ -1,10 +1,10 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vulkan-headers
-PKG_VERSION:=1.4.341.0
+PKG_VERSION:=1.4.350.0
 PKG_SOURCE:=Vulkan-Headers-vulkan-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/Vulkan-Headers/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=d73bc5036b6556b741f6985ff600ca720308c5f2850e4a43ceb498bd3de069e7
+PKG_HASH:=70270d10bf2c1e074a06ee37a50b75d332993d1b80a1d9526eeed2da6d82ed22
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=Apache-2.0 OR MIT

--- a/libs/vulkan-loader/Makefile
+++ b/libs/vulkan-loader/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vulkan-loader
-PKG_VERSION:=1.4.341.0
+PKG_VERSION:=1.4.350.0
 
 PKG_SOURCE:=Vulkan-Loader-vulkan-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/Vulkan-Loader/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=fe982697c780a950641bfcf94707135c26c501352242d285fa95d087d691292e
+PKG_HASH:=91f88fc43abb36821a568c7fbb3f815e9baf946d5fe187928df279708d45e509
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=Apache-2.0

--- a/libs/vulkan-tools/Makefile
+++ b/libs/vulkan-tools/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vulkan-tools
-PKG_VERSION:=1.4.341.0
+PKG_VERSION:=1.4.350.0
 
 PKG_SOURCE:=Vulkan-Tools-vulkan-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/Vulkan-Tools/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=dc65f1ea97dd0b2155c2281a79e87d27183c0737fb96377744091a3c8460ae1e
+PKG_HASH:=3079796d51b29ce49dc7b7c7e243df93b343d54c3be9d4a8292c3231b9698deb
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update the Vulkan stack together to LunarG SDK 1.4.350: vulkan-headers, vulkan-loader, vulkan-tools, spirv-headers and spirv-tools to 1.4.350.0 and glslang to 16.3.0 (the matching vulkan-sdk-1.4.350.0 tag).

---

## 🧪 Run Testing Details

Compile-tested only on `mediatek/filogic` (`aarch64_cortex-a53`); not run-tested on hardware.

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** —

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using `make package/<your-package>/refresh V=s`
- [x] It is structured in a way that it is potentially upstreamable
