### PR TITLE
libxkbcommon: update to version 1.13.2

### DIFF
--- a/libs/libxkbcommon/Makefile
+++ b/libs/libxkbcommon/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxkbcommon
-PKG_VERSION:=1.13.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.13.2
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=xkbcommon-$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/xkbcommon/$(PKG_NAME).git
-PKG_MIRROR_HASH:=aa1e7c8746054a1294129eb8f22b8e378c75361571079ee0cef97d1890632e75
+PKG_MIRROR_HASH:=84d08ef1896ca5eb84d29d6134c95ce0076eac2a1d91b87cc24ccfa5e70cbe25
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
@@ -22,7 +22,9 @@ include $(INCLUDE_DIR)/meson.mk
 MESON_ARGS += \
 	-Denable-x11=false \
 	-Denable-docs=false \
-	-Denable-wayland=true
+	-Denable-wayland=true \
+	-Dxkb-config-unversioned-extensions-path=/usr/share/xkeyboard-config.d \
+	-Dxkb-config-versioned-extensions-path=/usr/share/X11/xkb.d
 
 define Package/libxkbcommon
   SECTION:=libs

--- a/libs/libxkbcommon/patches/100-no-python.patch
+++ b/libs/libxkbcommon/patches/100-no-python.patch
@@ -1,6 +1,6 @@
 --- a/meson.build
 +++ b/meson.build
-@@ -1055,7 +1055,7 @@ test(
+@@ -1068,7 +1068,7 @@ test(
  pymod = import('python')
  python = pymod.find_installation('python3', modules: ['jinja2'], required: false)
  has_merge_modes_tests = python.found() and python.language_version().version_compare('>=3.11')


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update libxkbcommon to 1.13.2. Pass the xkb-config extensions-path options explicitly: 1.13.2 references DFLT_XKB_CONFIG_*_EXTENSIONS_PATH unconditionally in tools/info.c while meson only defines them when an xkeyboard-config root is detected, which otherwise breaks the build.

---

## 🧪 Run Testing Details

Compile-tested only on `mediatek/filogic` (`aarch64_cortex-a53`); not run-tested on hardware.

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** —

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using `make package/<your-package>/refresh V=s`
- [x] It is structured in a way that it is potentially upstreamable
