### PR TITLE
wlroots: update to version 0.20.1

### DIFF
--- a/frameworks/wlroots/Makefile
+++ b/frameworks/wlroots/Makefile
@@ -2,11 +2,11 @@ include $(TOPDIR)/rules.mk
 
 
 PKG_NAME:=wlroots
-PKG_VERSION:=0.20.0
+PKG_VERSION:=0.20.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/$(PKG_NAME)/$(PKG_NAME)/-/archive/$(PKG_VERSION)
-PKG_HASH:=e2d024916ed3bd011e058e78007655469e8c624fc338a28da610b087793b887b
+PKG_HASH:=e9e699a06492121153ce3a3448b0aa610f3285130754b85fbb58736c931fffec
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update wlroots to 0.20.1 (bugfix point release on the 0.20 stable series).

---

## 🧪 Run Testing Details

Compile-tested only on `mediatek/filogic` (`aarch64_cortex-a53`); not run-tested on hardware.

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** —

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using `make package/<your-package>/refresh V=s`
- [x] It is structured in a way that it is potentially upstreamable
