### PR TITLE
vulkan/spirv/glslang: update to Vulkan SDK 1.4.357.0

### DIFF
--- a/libs/glslang/Makefile
+++ b/libs/glslang/Makefile
@@ -1,15 +1,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glslang
-# 16.3.0 references the same commit as the Vulkan SDK 1.4.350.0 release tag
-# (vulkan-sdk-1.4.350.0); use the semver tag here to keep package-manager
+# 16.4.0 references the same commit as the Vulkan SDK 1.4.357.0 release tag
+# (vulkan-sdk-1.4.357.0); use the semver tag here to keep package-manager
 # version comparisons monotonic.
-PKG_VERSION:=16.3.0
+PKG_VERSION:=16.4.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=efff5a15258dce1ca2d323bf64c974f5fca03778174615dbc30c8d36db645bf5
+PKG_HASH:=c634d6237eb0cc04d5ddf5dc9955daa175d82b0f8797acab45b49965e9f6df13
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause BSD-2-Clause MIT Apache GPL-3.0-or-later

--- a/libs/spirv-headers/Makefile
+++ b/libs/spirv-headers/Makefile
@@ -1,11 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spirv-headers
-PKG_VERSION:=1.4.350.0
+PKG_VERSION:=1.4.357.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=SPIRV-Headers-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/SPIRV-Headers/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=9905d9341f20388adb852c77dd982f2c4d539fd68e6c1f1bcebf034715f2d1d5
+PKG_HASH:=4d703067a7e06331ccb37bdfed3f9b7879cc61969a2689ae95c95db34a47ff07
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT

--- a/libs/spirv-tools/Makefile
+++ b/libs/spirv-tools/Makefile
@@ -1,11 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spirv-tools
-PKG_VERSION:=1.4.350.0
+PKG_VERSION:=1.4.357.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=SPIRV-Tools-vulkan-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/SPIRV-Tools/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=446b288fe76d3f31bbf9a405d62b97020ac0f135edb0ed5dbdf1136c488138f5
+PKG_HASH:=d31e7109b6ef3559067e53e520870eafed7c9534d00db9728814b6df03fa4a5e
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT

--- a/libs/vulkan-headers/Makefile
+++ b/libs/vulkan-headers/Makefile
@@ -1,10 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vulkan-headers
-PKG_VERSION:=1.4.350.0
+PKG_VERSION:=1.4.357.0
+PKG_RELEASE:=1
 PKG_SOURCE:=Vulkan-Headers-vulkan-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/Vulkan-Headers/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=70270d10bf2c1e074a06ee37a50b75d332993d1b80a1d9526eeed2da6d82ed22
+PKG_HASH:=e87dce08116151f6b6d7de6b6faf41498e87e6cf848ff16fa3bd5402190ad4a3
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=Apache-2.0 OR MIT

--- a/libs/vulkan-loader/Makefile
+++ b/libs/vulkan-loader/Makefile
@@ -1,11 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vulkan-loader
-PKG_VERSION:=1.4.350.0
+PKG_VERSION:=1.4.357.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=Vulkan-Loader-vulkan-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/Vulkan-Loader/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=91f88fc43abb36821a568c7fbb3f815e9baf946d5fe187928df279708d45e509
+PKG_HASH:=54f2537df22313768da0317dda2abdaaab7711b4081c48c869a79db343d0ae70
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=Apache-2.0

--- a/libs/vulkan-tools/Makefile
+++ b/libs/vulkan-tools/Makefile
@@ -1,11 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vulkan-tools
-PKG_VERSION:=1.4.350.0
+PKG_VERSION:=1.4.357.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=Vulkan-Tools-vulkan-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/KhronosGroup/Vulkan-Tools/tar.gz/vulkan-sdk-$(PKG_VERSION)?
-PKG_HASH:=3079796d51b29ce49dc7b7c7e243df93b343d54c3be9d4a8292c3231b9698deb
+PKG_HASH:=6c94b86c850808aba316d999dd6742133d6197ae2135248d3a8aed9b32ebd1f7
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
**Maintainer:** @dangowrt

Joint bump of the Vulkan/SPIR-V stack to LunarG's latest released Vulkan SDK, 1.4.357.0 (from 1.4.350.0): vulkan-headers, vulkan-loader, vulkan-tools, spirv-headers, spirv-tools, and glslang (16.3.0 -> 16.4.0, which references the same commit as the vulkan-sdk-1.4.357.0 tag).

Deliberately tracks the SDK release tag rather than each repo's individual latest tag (which can be ahead of what's actually bundled in a released SDK, e.g. vulkan-headers/loader currently have newer untagged-as-SDK commits).

All 6 source hashes verified against two independent downloads (direct + codeload mirror where applicable); no patches in any of these 6 packages.
