### PR TITLE
harfbuzz: update to 14.3.1

### DIFF
--- a/libs/harfbuzz/Makefile
+++ b/libs/harfbuzz/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=harfbuzz
-PKG_VERSION:=14.2.1
+PKG_VERSION:=14.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/harfbuzz/harfbuzz/releases/download/$(PKG_VERSION)/
-PKG_HASH:=a54a5d8e9380a41fbb762ce367bcbf7704792dfca0d93f1bbca86c5a57902e0e
+PKG_HASH:=9dae9538aae2ffdf70cec31f2c27bf68e2aaeeae3112688467697d5faf6194f7
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1


### PR DESCRIPTION
**Maintainer:** @dangowrt

From 14.2.1: fixed AAT insertion at the end of the text; fixed various rendering bugs in the experimental GPU library; the WASM shaper can now read user features; various fuzzing, build and subsetting fixes.
