### PR TITLE
libdisplay-info: update to 0.4.0

### DIFF
--- a/libs/libdisplay-info/Makefile
+++ b/libs/libdisplay-info/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdisplay-info
-PKG_VERSION:=0.3.0
+PKG_VERSION:=0.4.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/$(PKG_VERSION)
-PKG_HASH:=2b467e3336aec63819d6aca28d7310d3dc7415b2b3a3c3a5aec9d3727053c078
+PKG_HASH:=787b58aec473830b0030251ba2b880560b4b3853dc5d6961a6e9701abae29b55
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
**Maintainer:** @dangowrt

From 0.3.0. Notable changes: added DisplayID v2 CTA-861 data block support (parsing and di-edid-decode printing), CTA data now searchable from DisplayID v2 extensions; added DisplayID type IV timing support; regenerated the CTA VIC table for CTA-861-I with a reverse timing-to-code lookup; wrapped DMT/VIC codes in typed structs; fixed a double free of cta_vics, an out-of-bounds VIC array access, a shift-operation overflow, and several failed-allocation/uninitialised-variable issues; cta error handling switched from errno to negative error numbers with several "don't fail on one bad block" fixes; disabled most v4l-utils build options by default.
