### PR TITLE
wayland: update to 1.26.0

### DIFF
--- a/frameworks/wayland/Makefile
+++ b/frameworks/wayland/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wayland
-PKG_VERSION:=1.25.0
+PKG_VERSION:=1.26.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/wayland/wayland/-/releases/$(PKG_VERSION)/downloads/
-PKG_HASH:=c065f040afdff3177680600f249727e41a1afc22fccf27222f15f5306faa1f03
+PKG_HASH:=64176eaa46e4969903e286f8e5ef8331affc17fdf03ac9b58381d2b23162b7a3
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
**Maintainer:** @dangowrt

From 1.25.0. Notable changes: added wl_fixes.ack_global_remove() and delivery of wl_registry.global_remove to a global's offer list; added the wl_pointer.warp event; added new wl_shm formats and a wl_shm_pool::error enum; added server-side wl_display_remove_socket_fd(); fixed a use-after-free in for_each_helper; several scanner fixes (dropped a redundant exit() after fail(), fixed the emitted types for new_id arguments, removed an unused arg_count); protocol documentation fixes.
