### PR TITLE
wlroots: update to version 0.20.2

### DIFF
--- a/frameworks/wlroots/Makefile
+++ b/frameworks/wlroots/Makefile
@@ -2,11 +2,12 @@ include $(TOPDIR)/rules.mk
 
 
 PKG_NAME:=wlroots
-PKG_VERSION:=0.20.1
+PKG_VERSION:=0.20.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/$(PKG_NAME)/$(PKG_NAME)/-/archive/$(PKG_VERSION)
-PKG_HASH:=e9e699a06492121153ce3a3448b0aa610f3285130754b85fbb58736c931fffec
+PKG_HASH:=972c7ac44b17828f4702bfae7cd8347346a3fb5b2c1076cfa2c3fcedac5ec343
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
**Maintainer:** @dangowrt

From 0.20.1. Several Xwayland hardening fixes for handling malformed/malicious client input: an out-of-bounds strndup() in read_surface_class(), removed VLAs for MIME type atom lists, use of const pointers for xcb_get_property_value(), no longer relying on the (removable) xcb_get_property_reply_t.value_len field, a WM_TRANSIENT_FOR length check, and checks against duplicate/mistyped WL_SURFACE_ID association messages. Also: intersect the visible area with the output layout in update_node_update_outputs(), don't send a new dmabuf feedback after a scene node is disabled, set CLOEXEC on client FDs in security_context_v1, emit set_parent when an Xwayland parent surface is destroyed, and check the drag-and-drop action/accepted state on touch-up.
